### PR TITLE
fix infinitely recursive PrefixFieldExpression

### DIFF
--- a/src/index.grammar
+++ b/src/index.grammar
@@ -693,15 +693,16 @@ stringInterpolation {
   operator<"$"> immediateParen operator<"("> !regular1 e !regular1 operator<")">
 }
 
-PrefixFieldExpression[@name=FieldEpxression] {
-  PrefixFieldExpression
+PrefixFieldExpression[@name=FieldExpression] {
+  (Identifier | PrefixFieldExpression)
   !immediate immediateDot !dot "." !dot
   FieldName
 }
+
 PrefixedString {
   Prefix { Identifier | PrefixFieldExpression }
   !immediate
-  
+
   (immediateDoubleQuote StringWithoutInterpolation |
   immediateDoubleQuote TripleStringWithoutInterpolation |
   immediateBackquote CommandStringWithoutInterpolation)

--- a/test/dral.txt
+++ b/test/dral.txt
@@ -80,9 +80,11 @@ SourceFile(CoefficientExpression(Number,Coefficient(TupleExpression(Identifier,I
 
 
 # BROKEN: FieldExpression in PrefixedString
-module.macro"aaa"
+Module.macro"aaa"
 ==>
-SourceFile()
+SourceFile(
+    PrefixedString(Prefix(FieldExpression(Identifier, FieldName)), StringWithoutInterpolation)
+)
 
 
 # FieldExpression in Coefficient

--- a/test/edge-cases.txt
+++ b/test/edge-cases.txt
@@ -894,3 +894,17 @@ SourceFile(
   QuoteExpression(ParenthesizedExpression(Operator)),
   QuoteExpression(ParenthesizedExpression(Operator)),
 )
+
+# Comment inside string
+
+md"  #  "
+Markdown.md"  #  "
+Markdown.α.md"  #  "
+
+==>
+
+SourceFile(
+    PrefixedString(Prefix(Identifier), StringWithoutInterpolation),
+    PrefixedString(Prefix(FieldExpression(Identifier, FieldName)), StringWithoutInterpolation),
+    PrefixedString(Prefix(FieldExpression(FieldExpression(Identifier, FieldName), FieldName)), StringWithoutInterpolation)
+)


### PR DESCRIPTION
This should hopefully fix the prefix string with a comment or interpolation inside it:

![image](https://user-images.githubusercontent.com/9824244/161421885-afd3e486-bf33-4db7-8b06-7d9c587ae47d.png)

@dralletje i can't remember the procedure to test in pluto tough and i failed to install it inside lang-julia (i can't npm install there for some reasons). is there any written docs for that?