### PR TITLE
Bump Lezer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plutojl/lezer-julia",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "lezer-based Julia grammar",
   "main": "dist/index.cjs",
   "module": "dist/index.es.js",
@@ -13,15 +13,15 @@
   "author": "Andrey Popp <me@andreypopp.com>",
   "license": "MIT",
   "devDependencies": {
-    "@lezer/generator": "^0.16.0",
-    "@rollup/plugin-node-resolve": "^9.0.0",
+    "@lezer/generator": "^1.1.1",
+    "@rollup/plugin-node-resolve": "^14.1.0",
     "mocha": "^8.1.3",
     "prettier": "^2.2.1",
-    "rollup": "^2.27.1"
+    "rollup": "^2.79.1"
   },
   "dependencies": {
-    "@lezer/common": "^0.16.0",
-    "@lezer/lr": "^0.16.3"
+    "@lezer/common": "^1.0.1",
+    "@lezer/lr": "^1.2.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a naïve attempt at targeting lezer `1.x.y` version. According to the generator's [Changelog](https://github.com/lezer-parser/generator/blob/main/CHANGELOG.md) shouldn't be of much harm. I could build and run tests, which produces the same failures as on the base branch :-).