### PR TITLE
Support multiline list comprehensions

### DIFF
--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -202,14 +202,15 @@ TupleExpression { tuple }
 
 // NOTE: binding `in` is a keyword, membership `in` is a function
 ForBinding { kwid<'outer'>? (Identifier | TupleExpression) !assignment AssignmentOp { '=' | '∈' | kwid<'in'> } expr }
-GenFor { kw<'for'> sep1<(!tup ','), ForBinding> }
+GenFor { kw<'for'> sep1<(!tup ','), ForBinding> (kw<'for'> sep1<(!tup ','), ForBinding>)* }
 GenFilter { kw<'if'> expr }
-Generator<expr> { expr !simple GenFor (GenFor | GenFilter)* }
+Generator<expr> { expr !simple GenFor GenFilter* }
+ArrayGenerator[@name=Generator]<expr> { expr ~gen-or-mat _t? !simple GenFor GenFilter* }
 
-MatrixRow { (!mat expr-idx)+ }
+MatrixRow { (expr-idx ~gen-or-mat)+ }
 
 array {
-  ( ComprehensionExpression { '[' Generator<expr-idx> ']' }
+  ( ComprehensionExpression { '[' ArrayGenerator<expr-idx> ']' }
   | MatrixExpression { '[' MatrixRow (_t MatrixRow)* _t? ']' }
   | VectorExpression { '[' sep<',', (!vec (expr-idx | binding-idx<'Assignment'>))> ']' }
   )

--- a/test/collections.txt
+++ b/test/collections.txt
@@ -139,6 +139,20 @@ Program(
 
 [x for x in xs]
 UInt[b(c, e) for c in d for e in f]
+[
+  a(1)
+  for a in f
+]
+[
+  a(1)
+  for a in f
+        ,b in e
+]
+[
+  a(1)
+  for a in f
+        for b in e
+]
 
 ==>
 Program(
@@ -153,11 +167,37 @@ Program(
     ComprehensionExpression(
       Generator(
         CallExpression(Identifier, Arguments(Identifier, Identifier)),
-        GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
-        GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
+        GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier), for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
       )
     )
-  )
+  ),
+  ComprehensionExpression(
+    Generator(
+      CallExpression(Identifier, Arguments(IntegerLiteral)),
+      GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
+    )
+  ),
+  ComprehensionExpression(
+    Generator(
+      CallExpression(Identifier, Arguments(IntegerLiteral)),
+      GenFor(
+        for, 
+        ForBinding(Identifier, AssignmentOp(in), Identifier),
+        ForBinding(Identifier, AssignmentOp(in), Identifier),
+      ),
+    )
+  ),
+  ComprehensionExpression(
+    Generator(
+      CallExpression(Identifier, Arguments(IntegerLiteral)),
+      GenFor(
+        for, 
+        ForBinding(Identifier, AssignmentOp(in), Identifier),
+        for,
+        ForBinding(Identifier, AssignmentOp(in), Identifier),
+      ),
+    )
+  ),
 )
 
 


### PR DESCRIPTION
## Summary

- Fixes multiline array comprehensions like `[\n  expr\n  for x in xs\n]` which previously failed with a parse error
- Multiple `for` clauses (`for a in f for b in e`) are now grouped into a single `GenFor` node
- Multiline continuation of bindings (`,b in e` on the next line) already worked and continues to work

## Root cause

The `!mat` precedence marker in `MatrixRow` was resolving the conflict with `ComprehensionExpression` *before* a GLR split could occur, always committing to the matrix interpretation. When the parser then saw `for`, it had no valid path and errored.

## Fix

Four small changes to `src/julia.grammar`:

1. **`MatrixRow`**: Replace `!mat` with `~gen-or-mat`. This enables a GLR split after parsing the first expression inside `[...]`, so both the matrix and comprehension paths are explored simultaneously.

2. **`ArrayGenerator`** (new, aliased as `Generator` in the tree): Used inside `ComprehensionExpression`. Carries the matching `~gen-or-mat` marker and adds `_t?` to accept a newline between the body expression and `for`.

3. **`GenFor`**: Extended to absorb multiple `for` groups — `for a in f for b in e` now produces a single `GenFor` node with two `for` children. Whitespace/newlines between groups are handled by `@skip`.

4. **`Generator`**: Simplified since `GenFor` now captures all `for` clauses (removed `(GenFor | GenFilter)*` → `GenFilter*`).

## Test plan

- [x] All 111 existing tests pass
- [x] New test cases added for multiline comprehensions (simple, comma-continuation, and double-`for`)
- [x] Matrix expressions (`[1 2; 3 4]`, `[1 2\n3 4]`) still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)