### PR TITLE
Fix :: precedence: a::T binds tighter than arithmetic operators

### DIFF
--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -2,9 +2,9 @@
   quote @left
   dot @left
   where @left // Inner `where`
-  decl @left
   power @right
   unary @right
+  decl @left
   juxt @right
   bitshift @left
   rational @left
@@ -73,6 +73,9 @@ expression<expr> {
 
 // Expression in "normal" context
 expr { expression<expr> | simple-statement | compound-statement | definition }
+
+// Type expressions (just an alias for expr, but creates a named node)
+Type { !decl expr }
 
 // Expressions inside arrays
 expr-idx { expression<expr-idx> | kw<'begin'> | kw<'end'> }
@@ -283,14 +286,14 @@ Symbol {
 operation<expr> {
   ( SplatExpression { expr !colon '...' }
   | UnaryExpression { (TildeOp | TypeComparisonOp | UnaryOp | UnaryPlusOp) !unary expr }
-  | [@name=UnaryExpression] { '::' !unary Type { expr } }
+  | [@name=UnaryExpression] { '::' !unary Type }
   | BinaryExpression<expr>
   )
 }
 
 BinaryExpression<expr> {
-  ( expr !where      kwid<'where'> !where Type { expr }
-  | expr !decl       '::' Type { expr }
+  ( expr !where      kwid<'where'> !where Type
+  | expr !decl       '::' !decl Type
   | expr !power      PowerOp !power expr
   | expr !bitshift   BitshiftOp !bitshift expr
   | expr !rational   RationalOp !rational expr

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -72,6 +72,22 @@ Program(
 )
 
 
+# Type declarations - Precedence
+
+a::One + b::Two
+a + b::Two
+
+==>
+Program(
+  BinaryExpression(
+    BinaryExpression(Identifier, Type(Identifier)),
+    UnaryPlusOp,
+    BinaryExpression(Identifier, Type(Identifier))
+  ),
+  BinaryExpression(Identifier, UnaryPlusOp, BinaryExpression(Identifier, Type(Identifier)))
+)
+
+
 # Arrow function expressions
 
 x -> x ^ 2


### PR DESCRIPTION
## Summary

- `a::One + b::Two` was incorrectly parsed as `a :: (One + b::Two)` instead of `(a::One) + (b::Two)`
- Root cause: the `Type { expr }` inline alias used on the right-hand side of `::` created an opaque production boundary that prevented the `!decl` precedence marker from propagating into the sub-expression
- Fix: define `Type` as a top-level rule with `!decl` as its internal precedence marker (`Type { !decl expr }`), so operators with lower priority than `decl` (arithmetic operators like `+`, `*`, etc.) terminate the type expression instead of extending it

As a bonus, the `where` rule also uses this same `Type` rule, so `a where T + b` now correctly parses as `(a where T) + b`.

**Before:**
```julia
a::One + b::Two  # → a :: (One + b::Two)   ✗
a::One * b       # → a :: (One * b)         ✗
```

**After:**
```julia
a::One + b::Two  # → (a::One) + (b::Two)   ✓
a::One * b       # → (a::One) * b           ✓
a + b::Two       # → a + (b::Two)           ✓  (unchanged)
a::T where T     # → a :: (T where T)       ✓  (unchanged)
```

## Test plan

- [x] All 113 tests pass (112 existing + 1 new test section "Type declarations - Precedence")
- [x] New test covers `a::One + b::Two` and `a + b::Two`

🤖 Generated with [Claude Code](https://claude.com/claude-code)