### PR TITLE
Allow any expression inside string interpolation $(…)

### DIFF
--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -380,7 +380,7 @@ string {
   ns<delim, content, esc> { _s<delim, content | '$' | '\\' | [@name=EscapeSequence]{ '\\\\' | esc }> }
 
   // Commands support the same interpolations as InterpExpression.
-  str-interp { Identifier | parens<expr> }
+  str-interp { Identifier | ParenExpression | TupleExpression }
   cmd-interp { Identifier | BraceExpression | ParenExpression | TupleExpression | array }
 
   // Strings can be single or triple quoted

--- a/test/literals.txt
+++ b/test/literals.txt
@@ -127,6 +127,17 @@ Program(
 )
 
 
+# String literals - Assignment inside interpolation
+
+"a $(b = c)"
+
+==>
+
+Program(
+  StringLiteral(ParenExpression(Assignment(Identifier, AssignmentOp, Identifier))),
+)
+
+
 # String literals - Triple quote delimiters
 
 """


### PR DESCRIPTION
## Summary

- Fixes `"$(b = c)"` (assignment inside string interpolation) and similar expressions that were previously rejected with a parse error
- Changes `str-interp` from the limited `parens<expr>` template to `ParenExpression | TupleExpression`, making it consistent with `cmd-interp` (command string interpolation) which already supported these forms
- `ParenExpression` allows assignments (`b = c`), generators (`x for x in xs`), and semicolon-separated expressions; `TupleExpression` allows tuples (`a, b`)

## Test plan

- [x] Added test case for `"a $(b = c)"` in `test/literals.txt`
- [x] All 114 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)