### PR TITLE
Fix trailing whitespace before newline breaking block statement separation

### DIFF
--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -114,7 +114,7 @@ simple-statement {
 
 Condition { expr _t? }
 ElseIfClause { kw<'elseif'> Condition block? }
-CatchClause  { kw<'catch'> ExceptionCapture { !simple Identifier }? block? }
+CatchClause  { kw<'catch'> ExceptionCapture[@dynamicPrecedence=1] { !simple Identifier }? _t? block? }
 ElseClause   { kw<'else'> block? }
 FinallyClause{ kw<'finally'> block? }
 

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -304,7 +304,7 @@ finally
 end
 
 try
-catch e 
+catch e
  e
 end
 
@@ -313,6 +313,15 @@ try catch e end
 try catch end
 try finally end
 
+try
+catch e_with_a_space_behind_it 
+end
+
+try
+catch e_with_a_space_behind_it 
+  body
+end
+
 ==>
 Program(
   TryStatement(
@@ -320,7 +329,7 @@ Program(
     Assignment(Identifier AssignmentOp CallExpression(Identifier Arguments(Identifier))),
     CatchClause(
       catch
-      Identifier
+      ExceptionCapture(Identifier)
       CallExpression(Identifier Arguments(Symbol(Identifier) Identifier))
     )
     ElseClause(
@@ -377,8 +386,27 @@ Program(
     )
     end
   )
-  
-  
+
+  TryStatement(
+    try
+    CatchClause(
+      catch
+      ExceptionCapture(Identifier)
+    )
+    end
+  )
+
+  TryStatement(
+    try
+    CatchClause(
+      catch
+      ExceptionCapture(Identifier)
+      Identifier
+    )
+    end
+  )
+
+
 )
 
 
@@ -532,4 +560,101 @@ Program(
 
   GlobalStatement(global, Assignment(CallExpression(Identifier, Arguments), AssignmentOp, IntegerLiteral)),
   GlobalStatement(global, FunctionDefinition(function, Signature(CallExpression(Identifier, Arguments)), IntegerLiteral, end)),
+)
+
+
+# Trailing space before for loop - issue #36
+
+function f()
+  x()
+  for i in z
+  end
+end
+
+==>
+Program(
+  FunctionDefinition(
+    function,
+    Signature(CallExpression(Identifier, Arguments)),
+    CallExpression(Identifier, Arguments),
+    ForStatement(
+      for,
+      ForBinding(Identifier, AssignmentOp(in), Identifier),
+      end
+    ),
+    end
+  )
+)
+
+
+# Trailing space before for loop - issue #36 - with trailing space
+
+function f()
+  x() 
+  for i in z
+  end
+end
+
+==>
+Program(
+  FunctionDefinition(
+    function,
+    Signature(CallExpression(Identifier, Arguments)),
+    CallExpression(Identifier, Arguments),
+    ForStatement(
+      for,
+      ForBinding(Identifier, AssignmentOp(in), Identifier),
+      end
+    ),
+    end
+  )
+)
+
+
+# Trailing space - exact issue #36 example
+
+@model function single_source_model()
+    MvNormal() 
+    for i in z
+    end
+end
+
+==>
+Program(
+  MacrocallExpression(
+    MacroIdentifier(Identifier),
+    MacroArguments(
+      FunctionDefinition(
+        function,
+        Signature(CallExpression(Identifier, Arguments)),
+        CallExpression(Identifier, Arguments),
+        ForStatement(
+          for,
+          ForBinding(Identifier, AssignmentOp(in), Identifier),
+          end
+        ),
+        end
+      )
+    )
+  )
+)
+
+
+# Trailing space - multiple statements in begin block
+
+begin
+  x 
+  y
+  z
+end
+
+==>
+Program(
+  BeginStatement(
+    begin,
+    Identifier,
+    Identifier,
+    Identifier,
+    end
+  )
 )


### PR DESCRIPTION
## Summary

- **`src/tokens.js`**: The `newline` external tokenizer now skips trailing spaces/tabs before looking for `\n`. Without this, a trailing space like `x() \n` would prevent the token from firing: external tokenizers run before `@skip`, so the skip rule would consume both the space and the newline together, leaving no `_t` separator between block statements (causing a parse error / error recovery).

- **`src/julia.grammar`**: Added `@dynamicPrecedence=1` and an explicit `_t?` after `ExceptionCapture` in `CatchClause`. The more-eager newline firing exposed a pre-existing GLR ambiguity where `catch e` competed with a path that put `e` in the block body instead of wrapping it in `ExceptionCapture`. These two changes ensure the ExceptionCapture path wins and can consume the newline correctly. This also fixes `ExceptionCapture` for `catch e\n body` (no trailing space), which was silently broken before.

Closes #36

## Test plan

- [x] New test `Trailing space before for loop - issue #36 - with trailing space` — the exact failing pattern from the issue, now parses cleanly
- [x] New test `Trailing space - exact issue #36 example` — the `@model function` example from the issue
- [x] New test `Trailing space - multiple statements in begin block` — trailing spaces on multiple consecutive lines
- [x] Updated `Try statements` — `catch exception` and `catch e` (with and without trailing space) now correctly produce `ExceptionCapture(Identifier)` in all cases
- [x] All 118 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)