### PR TITLE
Support `begin`/`end` indices inside larger expressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+Lezer grammar for Julia, used by Pluto.jl. Lenient by design: it's an editor
+grammar, so over-accepting invalid Julia is fine; mis-parsing or erroring on
+valid Julia is not.
+
+## Build & test workflow
+
+- `npm run prepare` — full build via rollup, **~2 minutes**. Required before
+  `npm test` picks up grammar changes (tests run against `dist/`, which is
+  gitignored).
+- Fast iteration: `node_modules/.bin/lezer-generator src/julia.grammar -o /tmp/out.js`
+  (~30–60s) reports grammar conflicts without bundling. Always do this first
+  after grammar edits; only run the full build once it's conflict-free.
+- `npm test` itself is instant (~50ms). Test files are `test/*.txt` in
+  `@lezer/generator/test` fileTests format; anonymous tokens like `"["` are
+  omitted from expectations, named nodes like `begin`, `AssignmentOp(in)` appear.
+
+## Validation beyond unit tests (do this for any grammar change)
+
+`experiments/` contains a differential-testing harness (see its README):
+parse thousands of real `.jl` files from `~/.julia/packages` with the
+published parser and the new build, compare error-node counts per file.
+Setup: `npm pack @plutojl/lezer-julia@<old-version>`, unpack into
+`node_modules/old-lezer-julia`. **Demand 0 regressed files** before
+considering a change done. Files "changed with same error count" need
+spot-checking — GLR tie flips hide there. `experiments/find-regression.js`
+shows source context of new error nodes in a file.
+
+Don't use `julia -e` to cross-check semantics: startup takes minutes here.
+Issue threads + JuliaSyntax behavior knowledge are faster oracles.
+
+## Grammar architecture (non-obvious)
+
+- The expression layer is **parameterized on index context**:
+  `expression<e>` / `primary-expr<e>` / `CallExpression<e>` / `tuple<e>` etc.
+  are instantiated with `expr` (normal) or `expr-idx` (inside `[...]`, where
+  `begin`/`end` are index values at any depth — issue #15). Index context
+  propagates through calls/parens/tuples/braces/arrow bodies and **resets**
+  inside block bodies (compound statements, do-blocks), matching Julia.
+- If you add a rule reachable from `expression<e>` that mentions
+  `primary-expr<expr>` (or anything expr-instantiated), you will get mass
+  reduce/reduce conflicts in idx states. Parameterize the rule instead
+  (this is why `OpenMacrocallExpression<e>` and `macro-head<e>` are parametric).
+- `compound-statement-idx` duplicates `compound-statement` for bracket
+  context. The `~bgn` marker after `kw<'begin'>` (in both `expr-idx` and the
+  idx `BeginStatement`) is what lets GLR fork begin-as-index vs begin-block.
+- `MatrixRow` elements are separated by the zero-length external token
+  `spaceSep` (whitespace containing no newline). This is what makes `[f(x)]`
+  a call instead of the juxtaposition `f`,`(x)`. `MatrixRow` carries
+  `@dynamicPrecedence=-1` purely to break GLR ties toward non-matrix readings.
+
+## Hard-won gotchas
+
+- **External tokenizers that call `stack.canShift` MUST be `contextual: true`.**
+  Otherwise their token is cached per-position and shared across GLR
+  branches; a branch where the token is invalid silently dies. This bug hid
+  for years in the `newline` tokenizer and only surfaced once brackets could
+  contain begin-blocks.
+- Even with contextual tokenizers, a GLR fork can only survive a newline if
+  **both branches can shift it**. That's why `begin`/`quote`/`try`/`else`/
+  `finally` have explicit `newline?` after the keyword. Use `newline?`, not
+  `_t?`: `_t` includes the `semicolon` token (`';'+`) which **overlaps the
+  `';'` literal** in ParenExpression/tuple separators → generator error
+  "Overlapping tokens semicolon and ';'". (Hence `begin; 1; end` still
+  doesn't parse — known pre-existing limitation.)
+- **`@dynamicPrecedence` is a global footgun.** Putting it on
+  `CallExpression` to win the matrix-juxtaposition ambiguity broke `:(x)`
+  and `$(x)` (they fork against call-with-Operator-head). Prefer making the
+  losing fork *impossible* (e.g. spaceSep) over dp; if you must use dp,
+  run the full corpus diff.
+- GLR ties (equal dp, both branches errorless) are resolved **arbitrarily
+  and context-dependently** — the same snippet can parse differently
+  depending on *following* lines. If a corpus file changes tree without
+  changing error count, suspect a tie and break it deterministically.
+- Token selection is parse-state-dependent: `'''` as CharLiteral and `x'''`
+  as triple adjoint coexist without conflict because the CharLiteral token
+  isn't valid in post-expression states.
+- `[a -1]` vs `[a - 1]` whitespace-sensitivity (Julia hvcat) is NOT modeled;
+  both parse as BinaryExpression. Same class: `[a ~b]` parses as binding.
+  Accepted leniency.
+
+## Project conventions
+
+- `memory/MEMORY.md` (untracked) has session notes overlapping this file.
+- Maintainer (fonsp) handles version bumps and `make release`; don't bump
+  `package.json` in PRs unless asked.
+- PRs: branch off `main`, `gh pr create --draft`. dist/ is never committed.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,45 @@
+# Experiments
+
+Standalone scripts used to validate the grammar changes for
+[issue #15](https://github.com/JuliaPluto/lezer-julia/issues/15)
+(`begin`/`end` indices inside larger expressions). They are not part of the
+test suite, but are useful for validating future grammar changes against
+real-world code.
+
+All scripts run against the built parser, so run `npm run prepare` first.
+
+## parse.js
+
+Parses a list of inline snippets (the cases from issue #15 plus related
+constructs) and checks whether each parses without error nodes.
+
+```
+node experiments/parse.js [--tree]
+```
+
+## diff-corpus.js, find-regression.js, perf.mjs
+
+Differential testing against the previously published parser, over a corpus
+of real Julia files. Setup:
+
+```
+# Old parser, unpacked where node can resolve it:
+cd /tmp && npm pack @plutojl/lezer-julia@0.12.7 && tar xf plutojl-lezer-julia-0.12.7.tgz
+cp -r /tmp/package node_modules/old-lezer-julia
+
+# Corpus: any list of .jl files, e.g.
+find ~/.julia/packages -name "*.jl" -size -200k | head -2000 > /tmp/julia-corpus-big.txt
+```
+
+Then:
+
+```
+# Compare trees and error-node counts old vs new (must report 0 regressed):
+node experiments/diff-corpus.js /tmp/julia-corpus-big.txt
+
+# Show source context of error nodes that are new in one file:
+node experiments/find-regression.js path/to/file.jl
+
+# Compare parse speed:
+node experiments/perf.mjs /tmp/julia-corpus-big.txt
+```

--- a/experiments/diff-corpus.js
+++ b/experiments/diff-corpus.js
@@ -1,0 +1,43 @@
+// Differential test: parse a corpus of real Julia files with the old
+// (published 0.12.7) and new (dist/) parsers; report error-node counts and
+// tree differences.
+// Usage: node experiments/diff-corpus.js /tmp/julia-corpus.txt
+import { readFileSync } from "node:fs";
+
+const newP = (await import("../dist/index.js")).parser;
+const oldP = (await import("old-lezer-julia")).parser;
+
+const files = readFileSync(process.argv[2], "utf8").trim().split("\n");
+
+function errorCount(tree) {
+  let n = 0;
+  tree.iterate({ enter(node) { if (node.type.isError) n++; } });
+  return n;
+}
+
+let same = 0, improved = 0, regressed = 0, changedSameErrs = 0;
+let oldTotalErrs = 0, newTotalErrs = 0;
+const regressions = [];
+
+for (const file of files) {
+  let code;
+  try { code = readFileSync(file, "utf8"); } catch { continue; }
+  const ot = oldP.parse(code), nt = newP.parse(code);
+  const oe = errorCount(ot), ne = errorCount(nt);
+  oldTotalErrs += oe; newTotalErrs += ne;
+  const sameTree = ot.toString() === nt.toString();
+  if (sameTree) same++;
+  else if (ne < oe) improved++;
+  else if (ne > oe) { regressed++; regressions.push([file, oe, ne]); }
+  else changedSameErrs++;
+}
+
+console.log(`files: ${files.length}`);
+console.log(`identical trees: ${same}`);
+console.log(`different trees, fewer errors (improved): ${improved}`);
+console.log(`different trees, same error count: ${changedSameErrs}`);
+console.log(`different trees, MORE errors (regressed): ${regressed}`);
+console.log(`total error nodes: old=${oldTotalErrs} new=${newTotalErrs}`);
+for (const [f, oe, ne] of regressions.slice(0, 20)) {
+  console.log(`  REGRESSED ${f}: ${oe} -> ${ne}`);
+}

--- a/experiments/find-regression.js
+++ b/experiments/find-regression.js
@@ -1,0 +1,25 @@
+// Locate new error nodes in a file: print source context around errors that
+// the new parser produces but the old one doesn't.
+import { readFileSync } from "node:fs";
+
+const newP = (await import("../dist/index.js")).parser;
+const oldP = (await import("old-lezer-julia")).parser;
+
+const file = process.argv[2];
+const code = readFileSync(file, "utf8");
+
+function errorPositions(tree) {
+  const out = [];
+  tree.iterate({ enter(n) { if (n.type.isError) out.push(n.from); } });
+  return out;
+}
+
+const oldErrs = new Set(errorPositions(oldP.parse(code)));
+const newErrs = errorPositions(newP.parse(code));
+
+for (const pos of newErrs) {
+  if (oldErrs.has(pos)) continue;
+  const line = code.slice(0, pos).split("\n").length;
+  console.log(`--- new error at offset ${pos} (line ${line}):`);
+  console.log(code.slice(Math.max(0, pos - 160), pos + 80).replace(/^/gm, "  "));
+}

--- a/experiments/parse.js
+++ b/experiments/parse.js
@@ -1,0 +1,70 @@
+// Standalone experiment: parse snippets and report whether they contain errors.
+// Usage: node experiments/parse.js [--tree] [file-with-snippets]
+import { parser } from "../dist/index.js";
+
+const showTree = process.argv.includes("--tree");
+
+const snippets = [
+  // From issue #15
+  ["data[begin]", true],
+  ["data[end]", true],
+  ["data[max(begin,i-1)]", true],
+  ["data[min(end,i+1)]", true],
+  // begin/end in nested expressions inside brackets
+  ["x[(begin)]", true],
+  ["x[(end)]", true],
+  ["x[end-1]", true],
+  ["x[begin+1]", true],
+  ["x[f(g(end))]", true],
+  ["x[(() -> begin)()]", true],
+  ["x[a ? begin : end]", true],
+  ["x[[begin for i in 1:3]]", true],
+  ["x[begin...]", true],
+  ["x[f(end; a=2)]", true],
+  ["x[f(a=end)]", true],
+  ["x[{end}]", true],
+  ["x[y[end]]", true],
+  ["x[end, begin]", true],
+  ["x[end end]", true], // matrix row: x[end end] is hvcat -> valid julia? `x[end end]` parse: yes matrix syntax
+  // Julia rejects begin-blocks in index position, but accepts them in array
+  // literals (`[begin 1 end]`); the grammar cannot distinguish the two
+  // contexts, so we leniently accept both.
+  ["x[begin\n1\nend]", true],
+  // Control: normal begin blocks outside brackets still work
+  ["begin\nx = 1\nend", true],
+  ["f(begin\nx\nend)", true],
+  ["let\nx[begin]\nend", true],
+  // From the issue, full example
+  [
+    `let
+	left = data[begin]
+	right = data[end]
+
+	left = data[max(begin,i-1)]
+	right = data[min(end,i+1)]
+
+	left < x > right
+end`,
+    true,
+  ],
+];
+
+let pass = 0, fail = 0;
+for (const [code, shouldParse] of snippets) {
+  const tree = parser.parse(code);
+  let hasError = false;
+  tree.iterate({
+    enter(n) {
+      if (n.type.isError) hasError = true;
+    },
+  });
+  const ok = hasError !== shouldParse;
+  if (ok) pass++; else fail++;
+  console.log(
+    `${ok ? "PASS" : "FAIL"} ${hasError ? "(error)  " : "(no err) "} ${JSON.stringify(code.length > 60 ? code.slice(0, 60) + "…" : code)}`
+  );
+  if (showTree || !ok) {
+    console.log("      " + tree.toString());
+  }
+}
+console.log(`\n${pass} pass, ${fail} fail`);

--- a/experiments/perf.mjs
+++ b/experiments/perf.mjs
@@ -1,0 +1,16 @@
+// Benchmark: parse a corpus of real Julia files with the old (published)
+// and new (dist/) parsers and compare wall-clock time.
+// Usage: node experiments/perf.mjs [file-list]   (default: /tmp/julia-corpus-big.txt)
+// See experiments/README.md for how to set up the corpus and old parser.
+import { readFileSync } from "node:fs";
+const newP = (await import("../dist/index.js")).parser;
+const oldP = (await import("old-lezer-julia")).parser;
+const files = readFileSync(process.argv[2] ?? "/tmp/julia-corpus-big.txt", "utf8").trim().split("\n");
+const codes = [];
+let bytes = 0;
+for (const f of files) { try { const c = readFileSync(f, "utf8"); codes.push(c); bytes += c.length; } catch {} }
+for (const [name, p] of [["old", oldP], ["new", newP], ["old", oldP], ["new", newP]]) {
+  const t0 = performance.now();
+  for (const c of codes) p.parse(c);
+  console.log(name, (performance.now() - t0).toFixed(0) + "ms", "for", (bytes/1e6).toFixed(1) + "MB");
+}

--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -41,30 +41,35 @@ OpenTuple { expr (!tup ',' expr)+ }
 
 // Assignments inside blocks, including top-level.
 OpenAssignment[@name=Assignment] {
-  (primary-expr | operation<expr> | Operator | OpenTuple)
+  (primary-expr<expr> | operation<expr> | Operator | OpenTuple)
   !assignment (AssignmentOp | UpdateOp | TildeOp) !assignment
   top-level
 }
 
 // Assignments inside brackets cannot contain OpenTuples.
-_binding<alias, expr> {
+_binding<alias, e> {
   [@name={alias}] {
-      (primary-expr | operation<expr> | Operator)
+      (primary-expr<e> | operation<e> | Operator)
       !assignment (AssignmentOp | UpdateOp | TildeOp) !assignment
-      (expr | _binding<'Assignment', expr>)
+      (e | _binding<'Assignment', e>)
   }
 }
 binding<alias> { _binding<alias, expr> }
 binding-idx<alias> { _binding<alias, expr-idx> }
 
 // Almost everything else is an expression.
-expression<expr> {
-  ( primary-expr
-  | operation<expr>
-  | OpenMacrocallExpression
-  | ArrowFunctionExpression
-  | JuxtapositionExpression
-  | TernaryExpression<expr>
+// The parameter `e` distinguishes the "normal" context (expr) from the
+// index context (expr-idx) inside square brackets, where `begin` and `end`
+// are valid values at any expression depth (issue #15). The parameter is
+// threaded through every construct that can nest expressions without
+// starting a new block scope.
+expression<e> {
+  ( primary-expr<e>
+  | operation<e>
+  | OpenMacrocallExpression<e>
+  | ArrowFunctionExpression<e>
+  | JuxtapositionExpression<e>
+  | TernaryExpression<e>
   | Operator
   | FloatLiteral
   | IntegerLiteral
@@ -77,8 +82,10 @@ expr { expression<expr> | simple-statement | compound-statement | definition }
 // Type expressions (just an alias for expr, but creates a named node)
 Type { !decl expr }
 
-// Expressions inside arrays
-expr-idx { expression<expr-idx> | kw<'begin'> | kw<'end'> }
+// Expressions inside arrays. `begin` and `end` are valid index values, and
+// compound statements are allowed (their bodies are normal blocks again),
+// except `begin` blocks: inside brackets `begin` always means the first index.
+expr-idx { expression<expr-idx> | kw<'begin'> ~bgn | kw<'end'> | compound-statement-idx }
 
 
 // STATEMENTS
@@ -115,12 +122,18 @@ simple-statement {
 Condition { expr _t? }
 ElseIfClause { kw<'elseif'> Condition block? }
 CatchClause  { kw<'catch'> ExceptionCapture[@dynamicPrecedence=1] { !simple Identifier }? _t? block? }
-ElseClause   { kw<'else'> block? }
-FinallyClause{ kw<'finally'> block? }
+ElseClause   { kw<'else'> newline? block? }
+FinallyClause{ kw<'finally'> newline? block? }
 
+// The explicit `newline?` after block-opening keywords lets the newline be
+// shifted as a token. Inside brackets this is essential: the newline after
+// `[begin` is also a possible matrix row separator, and both GLR branches
+// must be able to consume the same token to stay alive. (`_t?` would also
+// pull in the `semicolon` token, which overlaps with the `';'` separator
+// used by parenthesized expressions.)
 compound-statement[@isGroup=CompoundStatement] {
-  ( BeginStatement { kw<'begin'> block? end }
-  | QuoteStatement { kw<'quote'> block? end }
+  ( BeginStatement { kw<'begin'> newline? block? end }
+  | QuoteStatement { kw<'quote'> newline? block? end }
   | WhileStatement { kw<'while'> Condition block? end }
   | ForStatement { kw<'for'> sep1<',', ForBinding> _t? block? end }
   | LetStatement { kw<'let'> sep1<',', LetBinding { binding<'Assignment'> | Identifier }>? (_t block? end | end) }
@@ -128,29 +141,48 @@ compound-statement[@isGroup=CompoundStatement] {
       kw<'if'> Condition block? ElseIfClause* ElseClause? end
     }
   | TryStatement {
-      kw<'try'> block? (CatchClause ElseClause?)? FinallyClause? end
+      kw<'try'> newline? block? (CatchClause ElseClause?)? FinallyClause? end
     }
   )
 }
 
-TypeHead { primary-expr | BinaryExpression<expr> }
+// Same as compound-statement, for use inside brackets where `begin` and
+// `end` can also be index values. `begin ... end` blocks fork with
+// `begin`-as-index via GLR: `x[begin]` resolves to the index, while
+// `[begin f(x) end for i in xs]` resolves to a block body.
+compound-statement-idx[@isGroup=CompoundStatement] {
+  ( BeginStatement { kw<'begin'> ~bgn newline? block? end }
+  | QuoteStatement { kw<'quote'> newline? block? end }
+  | WhileStatement { kw<'while'> Condition block? end }
+  | ForStatement { kw<'for'> sep1<',', ForBinding> _t? block? end }
+  | LetStatement { kw<'let'> sep1<',', LetBinding { binding<'Assignment'> | Identifier }>? (_t block? end | end) }
+  | IfStatement {
+      kw<'if'> Condition block? ElseIfClause* ElseClause? end
+    }
+  | TryStatement {
+      kw<'try'> newline? block? (CatchClause ElseClause?)? FinallyClause? end
+    }
+  )
+}
+
+TypeHead { primary-expr<expr> | BinaryExpression<expr> }
 
 definition[@isGroup=Definition] {
   ( AbstractDefinition { kwid<'abstract'> kwid<'type'> TypeHead end }
   | PrimitiveDefinition { kwid<'primitive'> kwid<'type'> TypeHead IntegerLiteral end }
   | StructDefinition { kwid<'mutable'>? kw<'struct'> TypeHead (_t block?)? end } // TODO: Allow skipping terminator
   | ModuleDefinition { (kw<'module'> | kw<'baremodule'>) Identifier _t? block? end }
-  | MacroDefinition { 
+  | MacroDefinition {
       kw<'macro'>
       ( Signature { Identifier }
-      | Signature { CallExpression } _t? block?
+      | Signature { CallExpression<expr> } _t? block?
       )
       end
     }
   | FunctionDefinition {
       kw<'function'>
       ( Signature { Identifier }
-      | Signature { !simple (CallExpression | TupleExpression | BinaryExpression<expr>) } _t? block?
+      | Signature { !simple (CallExpression<expr> | TupleExpression<expr> | BinaryExpression<expr>) } _t? block?
       )
       end
     }
@@ -160,22 +192,22 @@ definition[@isGroup=Definition] {
 
 // PRIMARY EXPRESSIONS
 
-primary-expr {
+primary-expr<e> {
   ( Identifier
   | BoolLiteral { @specialize<Identifier, 'true' | 'false'> }
   | CharLiteral
   | Symbol
   | string
   | array
-  | BraceExpression
-  | ParenExpression
-  | TupleExpression
-  | AdjointExpression { primary-expr immediateQuote "'" }
-  | FieldExpression { primary-expr !dot immediateDot '.' Field { Symbol | QuoteExpression | string | Word } }
-  | IndexExpression { primary-expr immediateBracket array }
-  | ParametrizedExpression { primary-expr immediateBrace BraceExpression }
-  | CallExpression
-  | ClosedMacrocallExpression
+  | BraceExpression<e>
+  | ParenExpression<e>
+  | TupleExpression<e>
+  | AdjointExpression { primary-expr<e> immediateQuote "'" }
+  | FieldExpression { primary-expr<e> !dot immediateDot '.' Field { Symbol | QuoteExpression | string | Word } }
+  | IndexExpression { primary-expr<e> immediateBracket array }
+  | ParametrizedExpression { primary-expr<e> immediateBrace BraceExpression<e> }
+  | CallExpression<e>
+  | ClosedMacrocallExpression<e>
   | InterpExpression
   | QuoteExpression
   )
@@ -184,78 +216,76 @@ primary-expr {
 sep<delim, rule> { (rule (delim rule)* delim?)? }
 sep1<delim, rule> { rule (delim rule)* }
 
-BraceExpression { '{' sep<',', expr | binding<'Assignment'>> '}' }
-ParenExpression[@dynamicPrecedence=1] { '(' sep1<';', (expr | binding<'Assignment'> | Generator<expr>) ~tup-or-par> ')' }
+BraceExpression<e> { '{' sep<',', e | _binding<'Assignment', e>> '}' }
+ParenExpression[@dynamicPrecedence=1]<e> { '(' sep1<';', (e | _binding<'Assignment', e> | Generator<e>) ~tup-or-par> ')' }
 
 // Parentheses where multiple expressions are not allowed.
 parens[@name=ParenExpression]<x> { '(' x ')' }
 
-tuple {
+tuple<e> {
   '('
-  sep<',', expr | binding<'KwArg'> | Generator<expr>>
+  sep<',', e | _binding<'KwArg', e> | Generator<e>>
   ~tup-or-par
-  KeywordArguments { ';' sep<',', expr | binding<'KwArg'>> }?
+  KeywordArguments { ';' sep<',', e | _binding<'KwArg', e>> }?
   ')'
 }
 
 // Tuples and arguments are parsed the same, but used in different contexts.
-Arguments { tuple }
-TupleExpression { tuple }
+Arguments<e> { tuple<e> }
+TupleExpression<e> { tuple<e> }
 
 
 // NOTE: binding `in` is a keyword, membership `in` is a function
-ForBinding { kwid<'outer'>? (Identifier | TupleExpression) !assignment AssignmentOp { '=' | '∈' | kwid<'in'> } expr }
+ForBinding { kwid<'outer'>? (Identifier | TupleExpression<expr>) !assignment AssignmentOp { '=' | '∈' | kwid<'in'> } expr }
 GenFor { kw<'for'> sep1<(!tup ','), ForBinding> (kw<'for'> sep1<(!tup ','), ForBinding>)* }
 GenFilter { kw<'if'> expr }
-Generator<expr> { expr !simple GenFor GenFilter* }
-ArrayGenerator[@name=Generator]<expr> { expr ~gen-or-mat _t? !simple GenFor GenFilter* }
+Generator<e> { e !simple GenFor GenFilter* }
+ArrayGenerator[@name=Generator]<e> { e ~gen-or-mat _t? !simple GenFor GenFilter* }
 
-// TODO: This isn't great, it's a copy of compound-statement but without the `begin` block because it produces a conflict with the `kw<begin>` index.
-BlockBodyGenerator[@name=Generator] {
-  ( QuoteStatement { kw<'quote'> block? end }
-  | WhileStatement { kw<'while'> Condition block? end }
-  | ForStatement { kw<'for'> sep1<',', ForBinding> _t? block? end }
-  | LetStatement { kw<'let'> sep1<',', LetBinding { binding<'Assignment'> | Identifier }>? (_t block? end | end) }
-  | IfStatement { kw<'if'> Condition block? ElseIfClause* ElseClause? end }
-  | TryStatement { kw<'try'> block? (CatchClause ElseClause?)? FinallyClause? end }
-  )
-  _t? !simple GenFor GenFilter*
-}
-
-MatrixRow { (expr-idx ~gen-or-mat)+ }
+// Elements of a matrix row must be separated by whitespace (without a
+// newline, which separates rows instead). `spaceSep` is a zero-length token
+// that marks such whitespace. Requiring it here means `[f(x)]` is always a
+// call, never the juxtaposition of `f` and `(x)`, matching Julia.
+// Bindings are allowed as elements so that `[a ~ b\nc ~ d]` (common in
+// SciML code) parses as rows of `~` bindings.
+// The negative dynamic precedence breaks GLR ties like `[begin + 1]`
+// (BinaryExpression vs the row `begin`, `+1`) in favor of the other
+// interpretation; unambiguous matrices are unaffected.
+matrix-elem { expr-idx | binding-idx<'Assignment'> }
+MatrixRow[@dynamicPrecedence=-1] { matrix-elem ~gen-or-mat (spaceSep matrix-elem ~gen-or-mat)* }
 
 array {
-  ( ComprehensionExpression { '[' (ArrayGenerator<expr-idx> | BlockBodyGenerator) ']' }
+  ( ComprehensionExpression { '[' ArrayGenerator<expr-idx> ']' }
   | MatrixExpression { '[' MatrixRow (_t MatrixRow)* _t? ']' }
   | VectorExpression { '[' sep<',', (!vec (expr-idx | binding-idx<'Assignment'>))> ']' }
   )
 }
 
 
-DoClause[group=CompoundStatement]{ 
-  kw<'do'> Parameters { sep1<',', Identifier | TupleExpression | operation<expr>>? } 
-  (_t block? end | end) 
+DoClause[group=CompoundStatement]{
+  kw<'do'> Parameters { sep1<',', Identifier | TupleExpression<expr> | operation<expr>>? }
+  (_t block? end | end)
 }
 
-CallExpression {
-  (primary-expr (immediateDot '.')? | Operator)
-  immediateParen Arguments
+CallExpression<e> {
+  (primary-expr<e> (immediateDot '.')? | Operator)
+  immediateParen Arguments<e>
   DoClause?
 }
 
-macro-head { MacroIdentifier | [@name=FieldExpression]{ primary-expr immediateDot '.' MacroIdentifier } }
+macro-head<e> { MacroIdentifier | [@name=FieldExpression]{ primary-expr<e> immediateDot '.' MacroIdentifier } }
 
-ClosedMacrocallExpression[@name=MacrocallExpression] {
-  macro-head
+ClosedMacrocallExpression[@name=MacrocallExpression]<e> {
+  macro-head<e>
   ( immediateBracket array
-  | immediateBrace BraceExpression
-  | immediateParen Arguments
+  | immediateBrace BraceExpression<e>
+  | immediateParen Arguments<e>
   )
   DoClause?
 }
 
-OpenMacrocallExpression[@name=MacrocallExpression] {
-  macro-head
+OpenMacrocallExpression[@name=MacrocallExpression]<e> {
+  macro-head<e>
   MacroArguments { macro-arg[@dynamicPrecedence=-1] { (!macro top-level) }+ }?
 }
 
@@ -264,22 +294,22 @@ InterpExpression[@dynamicPrecedence=1] {
   '$' !quote
   ( Identifier
   | Operator
-  | BraceExpression
-  | ParenExpression
-  | TupleExpression
+  | BraceExpression<expr>
+  | ParenExpression<expr>
+  | TupleExpression<expr>
   | array
-  | ClosedMacrocallExpression
+  | ClosedMacrocallExpression<expr>
   // | OpenMacrocallExpression
   )
 }
 
 QuoteExpression[@dynamicPrecedence=1] {
   ':' !quote
-  ( immediateBrace BraceExpression
-  | immediateParen ParenExpression
-  | immediateParen TupleExpression
+  ( immediateBrace BraceExpression<expr>
+  | immediateParen ParenExpression<expr>
+  | immediateParen TupleExpression<expr>
   | immediateBracket array
-  | immediateAt ClosedMacrocallExpression
+  | immediateAt ClosedMacrocallExpression<expr>
   // | immediateAt OpenMacrocallExpression // TODO
   | immediateParen parens<SyntacticOperator>
   )
@@ -295,45 +325,45 @@ Symbol {
 
 // OPERATIONS
 
-operation<expr> {
-  ( SplatExpression { expr !colon '...' }
-  | UnaryExpression { (TildeOp | TypeComparisonOp | UnaryOp | UnaryPlusOp) !unary expr }
+operation<e> {
+  ( SplatExpression { e !colon '...' }
+  | UnaryExpression { (TildeOp | TypeComparisonOp | UnaryOp | UnaryPlusOp) !unary e }
   | [@name=UnaryExpression] { '::' !unary Type }
-  | BinaryExpression<expr>
+  | BinaryExpression<e>
   )
 }
 
-BinaryExpression<expr> {
-  ( expr !where      kwid<'where'> !where Type
-  | expr !decl       '::' !decl Type
-  | expr !power      PowerOp !power expr
-  | expr !bitshift   BitshiftOp !bitshift expr
-  | expr !rational   RationalOp !rational expr
-  | expr !times      TimesOp !times expr
-  | expr !plus       (PlusOp | UnaryPlusOp | Dollar { '$' }) !plus expr
-  | expr !colon      (EllipsisOp | Colon { ':' }) !colon expr
-  | expr !pipe-right PipeRightOp !pipe-right expr
-  | expr !pipe-left  PipeLeftOp !pipe-left expr
-  | expr !comparison (ComparisonOp | TypeComparisonOp | membership-operator) !comparison expr
-  | expr !lazy-and   LazyAndOp expr
-  | expr !lazy-or    LazyOrOp expr
-  | expr !arrow      ArrowOp !arrow expr
-  | expr !pair       PairOp !pair expr
+BinaryExpression<e> {
+  ( e !where      kwid<'where'> !where Type
+  | e !decl       '::' !decl Type
+  | e !power      PowerOp !power e
+  | e !bitshift   BitshiftOp !bitshift e
+  | e !rational   RationalOp !rational e
+  | e !times      TimesOp !times e
+  | e !plus       (PlusOp | UnaryPlusOp | Dollar { '$' }) !plus e
+  | e !colon      (EllipsisOp | Colon { ':' }) !colon e
+  | e !pipe-right PipeRightOp !pipe-right e
+  | e !pipe-left  PipeLeftOp !pipe-left e
+  | e !comparison (ComparisonOp | TypeComparisonOp | membership-operator) !comparison e
+  | e !lazy-and   LazyAndOp e
+  | e !lazy-or    LazyOrOp e
+  | e !arrow      ArrowOp !arrow e
+  | e !pair       PairOp !pair e
   )
 }
 
-ArrowFunctionExpression { (Identifier | TupleExpression) !afunc '->' !afunc (expr | binding<'Assignment'>) }
+ArrowFunctionExpression<e> { (Identifier | TupleExpression<e>) !afunc '->' !afunc (e | _binding<'Assignment', e>) }
 
 // JuxtapositionExpression is non-associative
 // TODO: Handle monomials like 3x^2 with the correct precedence
-JuxtapositionExpression {
-  ( (IntegerLiteral | FloatLiteral) ((!juxt immediateIdentifier primary-expr) | (!juxt immediateParen primary-expr))
-  | primary-expr (!juxt immediateIdentifier primary-expr)
+JuxtapositionExpression<e> {
+  ( (IntegerLiteral | FloatLiteral) ((!juxt immediateIdentifier primary-expr<e>) | (!juxt immediateParen primary-expr<e>))
+  | primary-expr<e> (!juxt immediateIdentifier primary-expr<e>)
   )
-  (!juxt immediateIdentifier primary-expr)*
+  (!juxt immediateIdentifier primary-expr<e>)*
 }
 
-TernaryExpression<expr> { expr !ternary '?' !ternary expr !ternary ':' !ternary expr }
+TernaryExpression<e> { e !ternary '?' !ternary e !ternary ':' !ternary e }
 
 
 Operator {
@@ -392,8 +422,8 @@ string {
   ns<delim, content, esc> { _s<delim, content | '$' | '\\' | [@name=EscapeSequence]{ '\\\\' | esc }> }
 
   // Commands support the same interpolations as InterpExpression.
-  str-interp { Identifier | ParenExpression | TupleExpression }
-  cmd-interp { Identifier | BraceExpression | ParenExpression | TupleExpression | array }
+  str-interp { Identifier | ParenExpression<expr> | TupleExpression<expr> }
+  cmd-interp { Identifier | BraceExpression<expr> | ParenExpression<expr> | TupleExpression<expr> | array }
 
   // Strings can be single or triple quoted
   StringLiteral  { s<str1-quote, str1-content, str-interp> | s<str3-quote, str3-content, str-interp> }
@@ -422,6 +452,7 @@ string {
   immediateQuote,
   immediateIdentifier
 }
+@external tokens spaceSep from "./tokens.js" { spaceSep }
 @external tokens word from "./tokens.js" { word }
 @external tokens Identifier from "./tokens.js" { Identifier }
 
@@ -509,7 +540,7 @@ _t { newline | semicolon }
     )
   }
 
-  CharLiteral { "'" (![\\'] | EscapeSequence) "'" }
+  CharLiteral { "'" (![\\'] | EscapeSequence) "'" | "'''" }
 
   str1-quote[@name='"', group=QuotationMark]{ '"' }
   cmd1-quote[@name='`', group=QuotationMark]{ '`' }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -260,7 +260,11 @@ export const newline = new ExternalTokenizer(
       input.acceptToken(terms.newline, offset);
       return;
     }
-  }
+  },
+  // The result depends on the parse stack (canShift), so it must not be
+  // cached across GLR branches: another branch at the same position may
+  // not accept a newline here.
+  { contextual: true },
 );
 
 // LAYOUT TOKENIZERS
@@ -276,6 +280,28 @@ const isWhitespace = (c) =>
   (c >= 8239 && c < 8240) ||
   (c >= 8287 && c < 8288) ||
   (c >= 12288 && c < 12289);
+
+// Zero-length token marking whitespace between elements of a matrix row
+// (`[a (b)]`). Only produced when the preceding whitespace contains no
+// newline: a newline separates matrix rows, not row elements. Without
+// preceding whitespace no token is produced, so `f(x)` inside brackets can
+// only be parsed as a call.
+export const spaceSep = new ExternalTokenizer(
+  (input, stack) => {
+    let offset = -1;
+    let c = input.peek(offset);
+    if (!isWhitespace(c)) return;
+    while (isWhitespace(c)) {
+      if (c === CHAR_NEWLINE) return;
+      c = input.peek(--offset);
+    }
+    if (stack.canShift(terms.spaceSep)) {
+      input.acceptToken(terms.spaceSep, 0);
+    }
+  },
+  // contextual: the canShift result differs between GLR branches.
+  { extend: true, contextual: true },
+);
 
 export const immediate = new ExternalTokenizer(
   (input, stack) => {

--- a/test/collections.txt
+++ b/test/collections.txt
@@ -215,6 +215,10 @@ Program(
 ]
 [if true; x end for x in xs]
 [while false; nothing end for x in xs]
+[begin
+  a = 1
+  a
+end for i in xs]
 
 ==>
 Program(
@@ -242,6 +246,26 @@ Program(
       GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
     )
   ),
+  ComprehensionExpression(
+    Generator(
+      BeginStatement(begin, Assignment(Identifier, AssignmentOp, IntegerLiteral), Identifier, end),
+      GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
+    )
+  ),
+)
+
+
+# Matrix rows of tilde bindings
+
+eqs = [D(x) ~ a * x
+       D(y) ~ b * y]
+
+==>
+Program(
+  Assignment(Identifier, AssignmentOp, MatrixExpression(
+    MatrixRow(Assignment(CallExpression(Identifier, Arguments(Identifier)), TildeOp, BinaryExpression(Identifier, TimesOp, Identifier))),
+    MatrixRow(Assignment(CallExpression(Identifier, Arguments(Identifier)), TildeOp, BinaryExpression(Identifier, TimesOp, Identifier))),
+  ))
 )
 
 

--- a/test/collections.txt
+++ b/test/collections.txt
@@ -255,6 +255,25 @@ Program(
 )
 
 
+# Comprehension arrays with begin block bodies - issue #44
+
+[
+	begin
+		1 + i
+	end for i in 1:10
+]
+
+==>
+Program(
+  ComprehensionExpression(
+    Generator(
+      BeginStatement(begin, BinaryExpression(IntegerLiteral, UnaryPlusOp, Identifier), end),
+      GenFor(for, ForBinding(Identifier, AssignmentOp(in), BinaryExpression(IntegerLiteral, Colon, IntegerLiteral))),
+    )
+  ),
+)
+
+
 # Matrix rows of tilde bindings
 
 eqs = [D(x) ~ a * x

--- a/test/primary.txt
+++ b/test/primary.txt
@@ -139,6 +139,42 @@ Program(
 )
 
 
+# Keywords as identifiers - begin/end indexing nested in larger expressions - issue #15
+
+data[max(begin, i - 1)]
+data[min(end, i + 1)]
+x[(begin)]
+x[f(a = end)]
+x[(() -> begin)()]
+
+==>
+Program(
+  IndexExpression(Identifier, VectorExpression(CallExpression(Identifier, Arguments(begin, BinaryExpression(Identifier, UnaryPlusOp, IntegerLiteral))))),
+  IndexExpression(Identifier, VectorExpression(CallExpression(Identifier, Arguments(end, BinaryExpression(Identifier, UnaryPlusOp, IntegerLiteral))))),
+  IndexExpression(Identifier, VectorExpression(ParenExpression(begin))),
+  IndexExpression(Identifier, VectorExpression(CallExpression(Identifier, Arguments(KwArg(Identifier, AssignmentOp, end))))),
+  IndexExpression(Identifier, VectorExpression(CallExpression(ParenExpression(ArrowFunctionExpression(TupleExpression, begin)), Arguments))),
+)
+
+
+# Compound statements inside index brackets
+
+x[let
+  2
+end]
+x[if a
+  1
+else
+  2
+end]
+
+==>
+Program(
+  IndexExpression(Identifier, VectorExpression(LetStatement(let, IntegerLiteral, end))),
+  IndexExpression(Identifier, VectorExpression(IfStatement(if, Condition(Identifier), IntegerLiteral, ElseClause(else, IntegerLiteral), end))),
+)
+
+
 # Type parametrized expressions
 
 Vector{Int}


### PR DESCRIPTION
Fixes #15. Fixes #44.

`begin` and `end` now parse as index values at any expression depth inside `[...]` — `data[max(begin, i-1)]`, `x[(() -> begin)()]`, `x[f(a = end)]`, etc. The full example from the issue parses error-free, and a differential test over 2000 real-world Julia files shows **zero regressions** with 26 files improved (total error nodes 1899 → 1825).

## How it works

The grammar already had a separate `expr-idx` rule for bracket contents, but it stopped at the top level: anything nested (call arguments, parens, braces, arrow bodies) fell back to plain `expr`. This PR parameterizes the whole expression layer (`primary-expr<e>`, `CallExpression<e>`, `tuple<e>`, `ParenExpression<e>`, …) on the expression context, instantiated with `expr` (normal) or `expr-idx` (inside brackets). Index context propagates into nested expressions and resets to normal context inside block bodies — both matching Julia (`a[(() -> begin)()]` is valid, `a[let begin end]` is not, per the experiments in the issue thread).

One non-obvious requirement: `OpenMacrocallExpression` must be parameterized too (just its head). Leaving it at `<expr>` pulls `primary-expr<expr>` into index states and causes mass reduce/reduce conflicts.

## What this unlocked along the way

- **Compound statements inside index brackets**: `x[let 2 end]`, `x[if a 1 else 2 end]` now parse (valid Julia, previously errors).
- **`begin`-blocks as comprehension bodies** (#44): `[begin a = 1; a end for i in xs]` — the case the old `BlockBodyGenerator` TODO called out as conflicting — now works via a GLR ambiguity marker (`~bgn`) that forks begin-as-index vs begin-as-block (`x[begin:end]` vs `[begin … end for i in xs]`). `BlockBodyGenerator` is now redundant (`ArrayGenerator<expr-idx>` subsumes it) and was removed.
- **`[f(x)]` is now a call**: previously it parsed as the matrix-row juxtaposition `f`, `(x)`. A new zero-length external token `spaceSep` requires actual whitespace between matrix row elements, like Julia. `MatrixRow` gets `@dynamicPrecedence=-1` to break remaining GLR ties (e.g. `[begin + 1]`: BinaryExpression vs row `begin`, `+1`) toward the non-matrix reading.
- **SciML-style equation arrays**: `[D(x) ~ a*x\n D(y) ~ b*y]` parses as matrix rows of `~` bindings. (It was previously error-free only by accident: each row parsed as the juxtaposition `D`, `(x)`, `~a*x`.)
- **`'''` char literal** (the quote character) now tokenizes; `x'''` still parses as a triple adjoint because token selection is state-dependent.

## Two subtle bugs found on the way

- The `newline` external tokenizer calls `stack.canShift()` but wasn't declared `contextual`, so its result was **cached across GLR branches**: after `[begin`, the matrix-interpretation branch can shift a newline (row separator) and that cached token forced the begin-block branch down a dead end. Both `newline` and the new `spaceSep` are now `contextual: true`.
- Block-opening keywords (`begin`/`quote`/`try`/`else`/`finally`) now accept an explicit `newline?` so that both GLR branches consume the newline as the same token and stay alive. `_t?` can't be used there: its `semicolon` token (`';'+`) overlaps the `';'` literal used as ParenExpression separator and the generator rejects the grammar. As a consequence `begin; 1; end` still doesn't parse — pre-existing limitation, unchanged by this PR.

## Validation

- All existing tests pass unchanged; new test groups cover nested begin/end indexing, compound statements in brackets, begin-comprehension bodies, tilde matrix rows, and the exact snippet from #44 (123 passing total).
- `experiments/` (included in this PR, see its README) contains the validation harness:
  - `parse.js` — the issue's snippets as expectations,
  - `diff-corpus.js` — differential old-vs-new parse over a corpus of real `.jl` files (from `~/.julia/packages`), comparing trees and error-node counts,
  - `find-regression.js` — shows source context for error nodes new in one parser,
  - `perf.mjs` — wall-clock comparison.
- Final corpus run (2000 files, 15.6 MB): 1565 identical trees, 409 changed with equal error counts (mostly `[f(x)]`-style juxtapositions becoming proper calls), 26 files with fewer errors, **0 files with more errors**.

## Costs

- The automaton roughly doubles for the expression sublanguage: `dist/index.js` grows ~20% (233 KB → 280 KB) and parsing is ~15–20% slower (~1.5 MB/s over the corpus). Seems acceptable for an incremental editor parser.

## Known leniencies (over-acceptance, in line with the rest of the grammar)

- `x[begin\n1\nend]` parses as a begin-block. Julia rejects begin-blocks in *index* position but accepts them in array literals; the grammar can't distinguish the two bracket contexts.
- `[a ~b]` parses as a binding rather than Julia's whitespace-sensitive hvcat of `a` and `~b` (the grammar can't see the space asymmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
