### PR TITLE
Support the `..` operator, macros in paren generators, fix `x[begin:end]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 package-lock.json
 memory/MEMORY.md
+/tmp-main-build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,20 @@ Issue threads + JuliaSyntax behavior knowledge are faster oracles.
   `spaceSep` (whitespace containing no newline). This is what makes `[f(x)]`
   a call instead of the juxtaposition `f`,`(x)`. `MatrixRow` carries
   `@dynamicPrecedence=-1` purely to break GLR ties toward non-matrix readings.
+- The generator `for` is its own external token (`genFor`, `extend: true` +
+  `canShift`), distinct from the `for` keyword. This is what lets
+  `sum(@show x for x in y)` fork: one branch shifts `genFor` (macro args end,
+  generator starts, matching Julia's `for_generator` rule), the other shifts
+  keyword `for` (a for-loop as the next macro argument, `f(@m x for i in y
+  end)`); the loser dies on error. A grammar-level fix is impossible — see
+  the conflict-marker gotcha below.
+- `..` lexes via the external `trailingInt` token: built-in `FloatLiteral`
+  accepts a trailing dot, so `1..2` would otherwise lex as `1.` `.2`.
+  External tokenizers run before `@tokens`, so `trailingInt` (decimal digits
+  immediately followed by two dots) wins there and only there. Leading dots
+  of relative imports (`import ..A`, `...A`) lex as `..`/`...` by maximal
+  munch; `ImportPath` accepts them, with `~impdots` forking against
+  `import Base: ..` (operator importable).
 
 ## Hard-won gotchas
 
@@ -73,6 +87,24 @@ Issue threads + JuliaSyntax behavior knowledge are faster oracles.
   and context-dependently** — the same snippet can parse differently
   depending on *following* lines. If a corpus file changes tree without
   changing error count, suspect a tie and break it deterministically.
+  The corpus also can't clear you of tie bugs it never exercises:
+  `x[begin:end]` misparsed as a begin-block with a bare-`Operator` body
+  (`:` is a valid expression!) and no corpus file contained it. Pluto cells
+  are short snippets, so snippet-level parses are what matter. Fixed with
+  `@dynamicPrecedence=-1` on the idx `BeginStatement`; the whole class is
+  `x[begin <op> end]` for any standalone-operator `<op>`.
+- **Precedence beats `~markers` in lezer-generator** (`addActionInner`):
+  a conflict already resolved by `!prec` ignores ambiguity markers
+  silently. Equalizing precedence on both sides activates the marker, but
+  for *every* lookahead token at that boundary, not just the one you care
+  about — for macro-args-vs-generator this exploded the table ("Goto table
+  too large"). When you need a fork on one specific token, give that token
+  its own contextual external tokenizer (`extend: true`) instead — that's
+  why `genFor` exists; same family of trick as `spaceSep`.
+- JuliaSyntax's `ParseState` flags are the oracle for context rules:
+  `for_generator=true` (set in `parse_call_arglist`) is why `for`
+  terminates open macro arguments inside any call/bracket/paren, while
+  `@simd for ... end` at statement level keeps the loop as an argument.
 - Token selection is parse-state-dependent: `'''` as CharLiteral and `x'''`
   as triple adjoint coexist without conflict because the CharLiteral token
   isn't valid in post-expression states.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -43,3 +43,10 @@ node experiments/find-regression.js path/to/file.jl
 # Compare parse speed:
 node experiments/perf.mjs /tmp/julia-corpus-big.txt
 ```
+
+## diff-vs-main.mjs
+
+Same as diff-corpus.js, but compares against a standalone build of the
+grammar at HEAD instead of the published package — useful for isolating the
+effect of uncommitted changes when main itself is ahead of the last release.
+Setup instructions are in the header comment of the script.

--- a/experiments/diff-vs-main.mjs
+++ b/experiments/diff-vs-main.mjs
@@ -1,0 +1,53 @@
+// Like diff-corpus.js, but diffs dist/ against a standalone build of the
+// grammar at HEAD (or any other ref) instead of the published package, to
+// isolate the effect of working-tree changes. Setup (from the repo root):
+//
+//   mkdir -p tmp-main-build
+//   git show HEAD:src/julia.grammar > tmp-main-build/julia.grammar
+//   git show HEAD:src/highlight.js > tmp-main-build/highlight.js
+//   git show HEAD:src/tokens.js \
+//     | sed 's|"./julia.grammar.terms"|"./julia.grammar.terms.js"|' \
+//     > tmp-main-build/tokens.js
+//   node_modules/.bin/lezer-generator tmp-main-build/julia.grammar \
+//     -o tmp-main-build/julia.grammar.js
+//
+// Usage: node experiments/diff-vs-main.mjs /tmp/julia-corpus.txt
+import { readFileSync } from "node:fs";
+
+const newP = (await import("../dist/index.js")).parser;
+const oldP = (await import("../tmp-main-build/julia.grammar.js")).parser;
+
+const files = readFileSync(process.argv[2], "utf8").trim().split("\n");
+
+function errorCount(tree) {
+  let n = 0;
+  tree.iterate({ enter(node) { if (node.type.isError) n++; } });
+  return n;
+}
+
+let same = 0, improved = 0, regressed = 0, changedSameErrs = 0;
+let oldTotalErrs = 0, newTotalErrs = 0;
+const regressions = [];
+
+for (const file of files) {
+  let code;
+  try { code = readFileSync(file, "utf8"); } catch { continue; }
+  const ot = oldP.parse(code), nt = newP.parse(code);
+  const oe = errorCount(ot), ne = errorCount(nt);
+  oldTotalErrs += oe; newTotalErrs += ne;
+  const sameTree = ot.toString() === nt.toString();
+  if (sameTree) same++;
+  else if (ne < oe) improved++;
+  else if (ne > oe) { regressed++; regressions.push([file, oe, ne]); }
+  else changedSameErrs++;
+}
+
+console.log(`files: ${files.length}`);
+console.log(`identical trees: ${same}`);
+console.log(`different trees, fewer errors (improved): ${improved}`);
+console.log(`different trees, same error count: ${changedSameErrs}`);
+console.log(`different trees, MORE errors (regressed): ${regressed}`);
+console.log(`total error nodes: old=${oldTotalErrs} new=${newTotalErrs}`);
+for (const [f, oe, ne] of regressions.slice(0, 20)) {
+  console.log(`  REGRESSED ${f}: ${oe} -> ${ne}`);
+}

--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -72,9 +72,13 @@ expression<e> {
   | TernaryExpression<e>
   | Operator
   | FloatLiteral
-  | IntegerLiteral
+  | integer
   )
 }
+
+// `1..2` lexes the `1` with the external trailingInt token (the built-in
+// FloatLiteral would otherwise swallow the first dot as `1.`).
+integer { IntegerLiteral | trailingInt }
 
 // Expression in "normal" context
 expr { expression<expr> | simple-statement | compound-statement | definition }
@@ -96,7 +100,9 @@ kwid[@dynamicPrecedence=1]<term> { @extend[@name={term},group='keyword']<Identif
 
 end { kw<'end'> }
 
-ImportPath { ('.'+ immediateIdentifier)? Identifier (!dot immediateDot '.' Identifier)* }
+// Leading dots of a relative import lex as `.`, `..` or `...` (maximal
+// munch, now that `..` is a token): `import ...A` is `...` `.A`.
+ImportPath { (('.' | EllipsisOp ~impdots | '...')+ immediateIdentifier)? Identifier (!dot immediateDot '.' Identifier)* }
 ImportAlias { importable kwid<'as'> exportable }
 
 exportable { Identifier | MacroIdentifier | Operator | parens<exportable> }
@@ -151,7 +157,11 @@ compound-statement[@isGroup=CompoundStatement] {
 // `begin`-as-index via GLR: `x[begin]` resolves to the index, while
 // `[begin f(x) end for i in xs]` resolves to a block body.
 compound-statement-idx[@isGroup=CompoundStatement] {
-  ( BeginStatement { kw<'begin'> ~bgn newline? block? end }
+  // The negative dynamic precedence breaks errorless GLR ties like
+  // `x[begin:end]` (a begin-block whose body is the bare operator `:`, vs
+  // the far more likely first-index:last-index reading) toward the index
+  // reading. Real begin-blocks in brackets win on error count, not ties.
+  ( BeginStatement[@dynamicPrecedence=-1] { kw<'begin'> ~bgn newline? block? end }
   | QuoteStatement { kw<'quote'> newline? block? end }
   | WhileStatement { kw<'while'> Condition block? end }
   | ForStatement { kw<'for'> sep1<',', ForBinding> _t? block? end }
@@ -237,7 +247,10 @@ TupleExpression<e> { tuple<e> }
 
 // NOTE: binding `in` is a keyword, membership `in` is a function
 ForBinding { kwid<'outer'>? (Identifier | TupleExpression<expr>) !assignment AssignmentOp { '=' | '∈' | kwid<'in'> } expr }
-GenFor { kw<'for'> sep1<(!tup ','), ForBinding> (kw<'for'> sep1<(!tup ','), ForBinding>)* }
+// The generator `for` is a distinct (external) token so that it can
+// GLR-fork against a for-loop reading of the same word, e.g. after open
+// macro-call arguments: `sum(@show x for x in y)`.
+GenFor { genFor sep1<(!tup ','), ForBinding> (genFor sep1<(!tup ','), ForBinding>)* }
 GenFilter { kw<'if'> expr }
 Generator<e> { e !simple GenFor GenFilter* }
 ArrayGenerator[@name=Generator]<e> { e ~gen-or-mat _t? !simple GenFor GenFilter* }
@@ -376,7 +389,9 @@ Operator {
   | RationalOp
   | TimesOp
   | PlusOp
-  | EllipsisOp
+  // ~impdots: `..` in import position GLR-forks between an importable
+  // operator (`import Base: ..`) and relative-import dots (`import ..A`).
+  | EllipsisOp ~impdots
   | Dollar { '$' }
   | Colon { ':' }
   | PipeRightOp
@@ -453,6 +468,8 @@ string {
   immediateIdentifier
 }
 @external tokens spaceSep from "./tokens.js" { spaceSep }
+@external tokens intBeforeRange from "./tokens.js" { trailingInt[@name=IntegerLiteral] }
+@external tokens genFor from "./tokens.js" { genFor[@name=for] }
 @external tokens word from "./tokens.js" { word }
 @external tokens Identifier from "./tokens.js" { Identifier }
 
@@ -479,7 +496,7 @@ _t { newline | semicolon }
   RationalOp { op<'//'> }
   TimesOp { op<$[*/%&\\] | $[⌿÷··⋅∘×∩∧⊗⊘⊙⊚⊛⊠⊡⊓∗∙∤⅋≀⊼⋄⋆⋇⋉⋊⋋⋌⋏⋒⟑⦸⦼⦾⦿⧶⧷⨇⨰⨱⨲⨳⨴⨵⨶⨷⨸⨻⨼⨽⩀⩃⩄⩋⩍⩎⩑⩓⩕⩘⩚⩜⩞⩟⩠⫛⊍▷⨝⟕⟖⟗⨟]> }
   PlusOp { op<'++' | '|' | $[−¦⊕⊖⊞⊟∪∨⊔∔∸≏⊎⊻⊽⋎⋓⟇⧺⧻⨈⨢⨣⨤⨥⨦⨧⨨⨩⨪⨫⨬⨭⨮⨹⨺⩁⩂⩅⩊⩌⩏⩐⩒⩔⩖⩗⩛⩝⩡⩢⩣]> }
-  EllipsisOp { op<$[…⁝⋮⋱⋰⋯]> } // TODO: `..` conflicts with ImportPath
+  EllipsisOp { op<$[…⁝⋮⋱⋰⋯]> | '..' } // `..` has the same precedence as `:` in Julia
   PipeRightOp { op<'|>'> }
   PipeLeftOp { op<'<|'> }
   ComparisonOp { op<'>=' | '<=' | '==' | '===' | '!=' | '!==' | $[><] | $[≥≤≡≠≢∈∉∋∌⊆⊈⊂⊄⊊∝∊∍∥∦∷∺∻∽∾≁≃≂≄≅≆≇≈≉≊≋≌≍≎≐≑≒≓≖≗≘≙≚≛≜≝≞≟≣≦≧≨≩≪≫≬≭≮≯≰≱≲≳≴≵≶≷≸≹≺≻≼≽≾≿⊀⊁⊃⊅⊇⊉⊋⊏⊐⊑⊒⊜⊩⊬⊮⊰⊱⊲⊳⊴⊵⊶⊷⋍⋐⋑⋕⋖⋗⋘⋙⋚⋛⋜⋝⋞⋟⋠⋡⋢⋣⋤⋥⋦⋧⋨⋩⋪⋫⋬⋭⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿⟈⟉⟒⦷⧀⧁⧡⧣⧤⧥⩦⩧⩪⩫⩬⩭⩮⩯⩰⩱⩲⩳⩵⩶⩷⩸⩹⩺⩻⩼⩽⩾⩿⪀⪁⪂⪃⪄⪅⪆⪇⪈⪉⪊⪋⪌⪍⪎⪏⪐⪑⪒⪓⪔⪕⪖⪗⪘⪙⪚⪛⪜⪝⪞⪟⪠⪡⪢⪣⪤⪥⪦⪧⪨⪩⪪⪫⪬⪭⪮⪯⪰⪱⪲⪳⪴⪵⪶⪷⪸⪹⪺⪻⪼⪽⪾⪿⫀⫁⫂⫃⫄⫅⫆⫇⫈⫉⫊⫋⫌⫍⫎⫏⫐⫑⫒⫓⫔⫕⫖⫗⫘⫙⫷⫸⫹⫺⊢⊣⟂⫪⫫]> }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -267,6 +267,83 @@ export const newline = new ExternalTokenizer(
   { contextual: true },
 );
 
+// GENERATOR `for`
+//
+// Inside a tuple/call/paren or bracket, a `for` following open macro-call
+// arguments is ambiguous: it can start another space-separated macro
+// argument (`f(@m x for i in y end)`, a for-loop) or it can be the `for` of
+// a generator, which terminates the macro call (`sum(@show x for x in y)`,
+// matching Julia). Producing a distinct token for the generator `for`
+// (extend: true, so it coexists with the regular keyword token) lets GLR
+// explore both readings; the for-loop reading dies when no `end` follows.
+
+const CHAR_f = "f".codePointAt(0);
+const CHAR_o = "o".codePointAt(0);
+const CHAR_r = "r".codePointAt(0);
+
+const isIdentifierContinueChar = (input, offset) => {
+  const c = input.peek(offset);
+  return (
+    (c >= CHAR_0 && c <= CHAR_9) ||
+    c === CHAR_UNDERSCORE ||
+    c === CHAR_EXCLAMATION ||
+    isIdentifierStartChar(input, offset) !== 0
+  );
+};
+
+export const genFor = new ExternalTokenizer(
+  (input, stack) => {
+    if (
+      input.peek(0) === CHAR_f &&
+      input.peek(1) === CHAR_o &&
+      input.peek(2) === CHAR_r &&
+      !isIdentifierContinueChar(input, 3) &&
+      stack.canShift(terms.genFor)
+    ) {
+      input.acceptToken(terms.genFor, 3);
+    }
+  },
+  // canShift ⇒ contextual (don't cache across GLR branches); extend so the
+  // regular `for` keyword token can coexist in the other branch.
+  { extend: true, contextual: true },
+);
+
+// NUMBERS BEFORE `..`
+//
+// The built-in FloatLiteral token allows a trailing dot (`1.`), so `1..2`
+// would lex as `1.` `.2`. Julia's lexer backs off the trailing dot when it
+// is followed by another dot, so `1..2` is `1 .. 2` (a range). This
+// tokenizer produces an IntegerLiteral for decimal digits that are
+// immediately followed by two dots; it is listed before the built-in
+// tokenizer, so it takes priority over FloatLiteral in exactly this case.
+
+export const intBeforeRange = new ExternalTokenizer((input, _stack) => {
+  let offset = 0;
+  let c = input.peek(offset);
+  if (c < CHAR_0 || c > CHAR_9) return;
+  while (true) {
+    c = input.peek(++offset);
+    if (c >= CHAR_0 && c <= CHAR_9) continue;
+    if (c === CHAR_UNDERSCORE) {
+      // An underscore must be followed by another digit to stay inside the
+      // numeral (`1_000`); otherwise the numeral ended before it (`12_`).
+      const next = input.peek(offset + 1);
+      if (next >= CHAR_0 && next <= CHAR_9) {
+        offset += 1;
+        continue;
+      }
+    }
+    break;
+  }
+  if (c !== CHAR_DOT) return;
+  // Hex/octal/binary literals (`0x1`) never end in a bare trailing dot, and
+  // exponents (`1e3`) consume their digits, so plain decimal digits are the
+  // only case that needs the back-off.
+  if (input.peek(offset + 1) === CHAR_DOT) {
+    input.acceptToken(terms.trailingInt, offset);
+  }
+});
+
 // LAYOUT TOKENIZERS
 
 const isWhitespace = (c) =>

--- a/test/collections.txt
+++ b/test/collections.txt
@@ -274,6 +274,32 @@ Program(
 )
 
 
+# Typed comprehensions - issue #45
+
+Float64[i for i in 1:3]
+T[i + j for i in 1:3, j in 1:3]
+
+==>
+Program(
+  IndexExpression(Identifier, ComprehensionExpression(
+    Generator(
+      Identifier,
+      GenFor(for, ForBinding(Identifier, AssignmentOp(in), BinaryExpression(IntegerLiteral, Colon, IntegerLiteral))),
+    )
+  )),
+  IndexExpression(Identifier, ComprehensionExpression(
+    Generator(
+      BinaryExpression(Identifier, UnaryPlusOp, Identifier),
+      GenFor(
+        for,
+        ForBinding(Identifier, AssignmentOp(in), BinaryExpression(IntegerLiteral, Colon, IntegerLiteral)),
+        ForBinding(Identifier, AssignmentOp(in), BinaryExpression(IntegerLiteral, Colon, IntegerLiteral)),
+      ),
+    )
+  )),
+)
+
+
 # Matrix rows of tilde bindings
 
 eqs = [D(x) ~ a * x

--- a/test/macros.txt
+++ b/test/macros.txt
@@ -272,3 +272,45 @@ Program(
     BinaryExpression(Identifier, UnaryPlusOp, Identifier),
   )
 )
+
+
+# Open macro calls terminated by a generator `for` - issue #24
+
+[@show (index) for index in eachindex(r_v)]
+[@__FILE__ for index in eachindex(r_v)]
+sum(@show x for x in y)
+f(@m x for i in y end)
+
+==>
+Program(
+  ComprehensionExpression(
+    Generator(
+      MacrocallExpression(MacroIdentifier(Identifier), MacroArguments(ParenExpression(Identifier))),
+      GenFor(for, ForBinding(Identifier, AssignmentOp(in), CallExpression(Identifier, Arguments(Identifier)))),
+    )
+  ),
+  ComprehensionExpression(
+    Generator(
+      MacrocallExpression(MacroIdentifier(Identifier)),
+      GenFor(for, ForBinding(Identifier, AssignmentOp(in), CallExpression(Identifier, Arguments(Identifier)))),
+    )
+  ),
+  CallExpression(
+    Identifier,
+    Arguments(
+      Generator(
+        MacrocallExpression(MacroIdentifier(Identifier), MacroArguments(Identifier)),
+        GenFor(for, ForBinding(Identifier, AssignmentOp(in), Identifier)),
+      )
+    )
+  ),
+  CallExpression(
+    Identifier,
+    Arguments(
+      MacrocallExpression(
+        MacroIdentifier(Identifier),
+        MacroArguments(Identifier, ForStatement(for, ForBinding(Identifier, AssignmentOp(in), Identifier), end)),
+      )
+    )
+  ),
+)

--- a/test/operators.txt
+++ b/test/operators.txt
@@ -153,13 +153,27 @@ Program(
 
 1:10
 x:y+1
-# 1..10 # TODO: Fix conflict with ImportPath: BinaryExpression(IntegerLiteral, IntegerLiteral)
 
 ==>
 Program(
   BinaryExpression(IntegerLiteral, Colon, IntegerLiteral),
   BinaryExpression(Identifier, Colon, BinaryExpression(Identifier, UnaryPlusOp, IntegerLiteral)),
-  LineComment,
+)
+
+
+# Binary `..` operator - issue #30
+
+1..10
+1.0 .. 2.0
+a..b
+x[2..end]
+
+==>
+Program(
+  BinaryExpression(IntegerLiteral, EllipsisOp, IntegerLiteral),
+  BinaryExpression(FloatLiteral, EllipsisOp, FloatLiteral),
+  BinaryExpression(Identifier, EllipsisOp, Identifier),
+  IndexExpression(Identifier, VectorExpression(BinaryExpression(IntegerLiteral, EllipsisOp, end))),
 )
 
 

--- a/test/primary.txt
+++ b/test/primary.txt
@@ -139,6 +139,20 @@ Program(
 )
 
 
+# Keywords as identifiers - begin/end indexing with range operators
+
+xs[begin:end]
+xs[begin..end]
+data[begin:2:end]
+
+==>
+Program(
+  IndexExpression(Identifier, VectorExpression(BinaryExpression(begin, Colon, end))),
+  IndexExpression(Identifier, VectorExpression(BinaryExpression(begin, EllipsisOp, end))),
+  IndexExpression(Identifier, VectorExpression(BinaryExpression(BinaryExpression(begin, Colon, IntegerLiteral), Colon, end))),
+)
+
+
 # Keywords as identifiers - begin/end indexing nested in larger expressions - issue #15
 
 data[max(begin, i - 1)]

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -470,12 +470,28 @@ import Module: ==, +
 Program(
   UsingStatement(using, ImportPath(Identifier)),
   UsingStatement(using, ImportPath(Identifier), ImportPath(Identifier), ImportPath(Identifier)),
-  UsingStatement(using, ImportPath(Identifier), ImportPath(Identifier), ),
+  UsingStatement(using, ImportPath(EllipsisOp, Identifier), ImportPath(EllipsisOp, Identifier), ),
 
   ImportStatement(import, ImportPath(Identifier, Identifier)),
   UsingStatement(using, SelectedImport(ImportPath(Identifier), ImportPath(Identifier), ImportPath(Identifier))),
   ImportStatement(import, SelectedImport(ImportPath(Identifier), MacroIdentifier(Identifier))),
   ImportStatement(import, SelectedImport(ImportPath(Identifier), Operator(ComparisonOp), Operator(UnaryPlusOp)))
+)
+
+
+# Import statements - relative import dots and the `..` operator - issue #30
+
+import ...A
+import ....A.b
+using Intervals: ..
+import Base: .. as dd
+
+==>
+Program(
+  ImportStatement(import, ImportPath(Identifier)),
+  ImportStatement(import, ImportPath(Identifier, Identifier)),
+  UsingStatement(using, SelectedImport(ImportPath(Identifier), Operator(EllipsisOp))),
+  ImportStatement(import, SelectedImport(ImportPath(Identifier), ImportAlias(Operator(EllipsisOp), as, Identifier))),
 )
 
 


### PR DESCRIPTION
Closes #30. Also completes #24 (paren/call generators) and adds tests for #24 and #45.

## 1. `..` operator (#30)

`1..2`, `1.0 .. 2.0`, `a..b`, `x[2..end]`, `x[begin..end]`, `using Intervals: ..`, `import Base: .. as dd` all parse now. Three coordinated changes:

- `'..'` added to `EllipsisOp` — Julia gives `..` the same precedence as `:`, which is exactly the level `EllipsisOp` already sits at (resolves the old TODO in the grammar).
- New external token `trailingInt`: the built-in `FloatLiteral` accepts a trailing dot, so `1..2` would lex as `1.` `.2`. The external tokenizer (which runs before the built-in one) emits an `IntegerLiteral` for decimal digits immediately followed by two dots, replicating Julia's lexer back-off. Hex/binary/exponent literals can't end in a bare trailing dot, so plain decimals are the only case that needs it.
- `ImportPath` accepts `..`/`...` tokens as relative-import dots, since maximal munch now lexes `import ..A` with a `..` token. The `~impdots` marker GLR-forks `import ....A` (dots) against `import Base: ..` (operator importable). **Tree change:** the leading dots of `import ..A` now appear as one `EllipsisOp` node instead of two anonymous `"."` tokens — worth double-checking against Pluto's import handling.

## 2. Open macro calls terminated by a generator `for` (completes #24)

The bracket cases from #24 were already fixed by #46; this extends the fix to paren/call generators: `sum(@show x for x in y)`, `Dict(@m i for i in x)`. JuliaSyntax terminates space-separated macro arguments at `for` inside any call arglist (`for_generator=true` in `parse_call_arglist`).

The generator `for` is now a distinct contextual external token (`genFor`, `extend: true`), so GLR forks it against the for-loop-argument reading; the wrong branch dies on error. Both readings keep working:

- `sum(@show x for x in y)` → generator, macro takes only `x`
- `f(@m x for i in y end)` → for-loop as second macro argument

A grammar-level fix isn't possible here: lezer resolves precedence *before* conflict markers, and equalizing precedences to activate a marker blows up the parse table ("Goto table too large") because it applies to every lookahead token at the macro-argument boundary, not just `for`. Documented in CLAUDE.md.

## 3. `x[begin:end]` misparse (unreleased regression from #46)

`x[begin:end]` parsed errorless as `BeginStatement(begin, Operator(:), end)` — a begin-block whose body is the bare operator `:`. This is an errorless GLR tie (the class is `x[begin <op> end]` for any standalone operator), so the corpus diff's error-count gate couldn't see it, and no corpus file happens to contain the pattern — but Pluto cells are exactly the kind of short snippet where the tie lands wrong. Fixed with `@dynamicPrecedence=-1` on the idx-context `BeginStatement` only; genuine begin-blocks in brackets (`[begin 1 end]`, comprehension bodies, multi-line blocks) still win on error count:

- `x[begin:end]` → `BinaryExpression(begin, Colon, end)` ✔
- `[begin x end for i in y]` → block body ✔

## Tests & validation

- 128 unit tests pass (new sections for `..`, relative imports, paren generators, typed comprehensions #45, `begin:end` indexing; one expectation updated for the ImportPath tree change).
- 2000-file corpus diff vs main: **0 regressed**, 38 improved, total error nodes **1825 → 783** (`..` was the bulk of remaining real-world errors). All 31 "changed, same error count" files programmatically verified to be only the ImportPath tree change.
- Corpus diff vs published 0.12.7: 0 regressed, 64 improved, 1899 → 783.
- Parse speed: ~2–7% slower than main on the corpus (the new tokenizers bail on the first character at almost every position).
- New `experiments/diff-vs-main.mjs` diffs dist/ against a standalone build of HEAD, for isolating working-tree changes when main is ahead of the last release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)