### PR TITLE
Fix CRLF, `public` soft-keyword, `const` struct fields, and uppercase-`P` hex floats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,26 +66,11 @@ Issue threads + JuliaSyntax behavior knowledge are faster oracles.
 
 ## Hard-won gotchas
 
-- **The `newline` external tokenizer must treat `\r` as a line break.** Julia
-  ends lines with `\n`, `\r`, or `\r\n`; the tokenizer's newline-consume loop
-  accepts `\r`/`\n` (and its trailing-whitespace skip is space/tab only, so
-  `\r` is consumed as part of the newline, not skipped). Otherwise a CRLF file
-  produces no newline token and every statement boundary + matrix/vcat row past
-  the first errors (`spaceSep`'s "is this a row separator?" check also tests
-  `\r`). Found by the 40k-file corpus sweep; mostly-LF corpora hide it.
 - **Soft keywords use `kwid<>` (`@extend`), hard keywords use `kw<>`
   (`@specialize`).** `kw<'public'>` made `public` unusable as an identifier
   (`x = public`, `f(public)`, `@public`, `macro public`); `kwid<'public'>`
   (like `as`/`outer`/`in`) keeps the `public x, y` statement working while
   letting `public` be an ordinary identifier elsewhere.
-- **`const` uses `top-level`, not `OpenAssignment`** (matching `global`/`local`)
-  so a bare `const x::T` field declaration parses (Julia 1.8+ const struct
-  fields, used throughout Base). A narrower rule is impossible: `const` is
-  reachable inside `expr` (via `simple-statement`), so any new rule reducing
-  from a shared expr-nonterminal is a *fatal* reduce/reduce conflict. The cost:
-  `const $$sym = $$scall` (double-interp inside a quote) flips to the bare-decl
-  reading — a pre-existing `$$`-as-juxtaposition weakness surfacing, not a const
-  bug (1 corpus file, a non-interactive MLStyle benchmark).
 - **External tokenizers that call `stack.canShift` MUST be `contextual: true`.**
   Otherwise their token is cached per-position and shared across GLR
   branches; a branch where the token is invalid silently dies. This bug hid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,26 @@ Issue threads + JuliaSyntax behavior knowledge are faster oracles.
 
 ## Hard-won gotchas
 
+- **The `newline` external tokenizer must treat `\r` as a line break.** Julia
+  ends lines with `\n`, `\r`, or `\r\n`; the tokenizer's newline-consume loop
+  accepts `\r`/`\n` (and its trailing-whitespace skip is space/tab only, so
+  `\r` is consumed as part of the newline, not skipped). Otherwise a CRLF file
+  produces no newline token and every statement boundary + matrix/vcat row past
+  the first errors (`spaceSep`'s "is this a row separator?" check also tests
+  `\r`). Found by the 40k-file corpus sweep; mostly-LF corpora hide it.
+- **Soft keywords use `kwid<>` (`@extend`), hard keywords use `kw<>`
+  (`@specialize`).** `kw<'public'>` made `public` unusable as an identifier
+  (`x = public`, `f(public)`, `@public`, `macro public`); `kwid<'public'>`
+  (like `as`/`outer`/`in`) keeps the `public x, y` statement working while
+  letting `public` be an ordinary identifier elsewhere.
+- **`const` uses `top-level`, not `OpenAssignment`** (matching `global`/`local`)
+  so a bare `const x::T` field declaration parses (Julia 1.8+ const struct
+  fields, used throughout Base). A narrower rule is impossible: `const` is
+  reachable inside `expr` (via `simple-statement`), so any new rule reducing
+  from a shared expr-nonterminal is a *fatal* reduce/reduce conflict. The cost:
+  `const $$sym = $$scall` (double-interp inside a quote) flips to the bare-decl
+  reading — a pre-existing `$$`-as-juxtaposition weakness surfacing, not a const
+  bug (1 corpus file, a non-interactive MLStyle benchmark).
 - **External tokenizers that call `stack.canShift` MUST be `contextual: true`.**
   Otherwise their token is cached per-position and shared across GLR
   branches; a branch where the token is invalid silently dies. This bug hid

--- a/experiments/PRODUCTION-READINESS.md
+++ b/experiments/PRODUCTION-READINESS.md
@@ -70,3 +70,13 @@ Items #4–#9 are a metaprogramming long tail.
 
 Every grammar change must be validated with the `experiments/` corpus diff
 demanding **0 regressions** before merge.
+
+## Outcome (PR #49)
+
+Landed CRLF, the `public` soft-keyword, `const` struct fields, and a fourth gap
+found during this analysis — **uppercase-`P` hex floats** (`0x1.8P3`; `hex-exp`
+matched only lowercase `p`). Combined: **256 corpus files improved**, total
+error nodes **85,192 → 37,479 (−56%)**, file clean-parse rate 92.9% → 93.4%,
+with 1 accepted regression (a non-interactive `MLStyle` benchmark hitting a
+pre-existing `$$`-interpolation weakness). Remaining gaps are tracked as issues
+#51–#57.

--- a/experiments/PRODUCTION-READINESS.md
+++ b/experiments/PRODUCTION-READINESS.md
@@ -75,8 +75,68 @@ demanding **0 regressions** before merge.
 
 Landed CRLF, the `public` soft-keyword, `const` struct fields, and a fourth gap
 found during this analysis — **uppercase-`P` hex floats** (`0x1.8P3`; `hex-exp`
-matched only lowercase `p`). Combined: **256 corpus files improved**, total
-error nodes **85,192 → 37,479 (−56%)**, file clean-parse rate 92.9% → 93.4%,
-with 1 accepted regression (a non-interactive `MLStyle` benchmark hitting a
-pre-existing `$$`-interpolation weakness). Remaining gaps are tracked as issues
-#51–#57.
+matched only lowercase `p`). Remaining gaps are tracked as issues #51–#57.
+
+### Completeness (40,402-file corpus)
+
+| Metric | Pre-PR baseline | After PR #49 |
+|--------|-----------------|--------------|
+| Files parsing clean (zero error nodes) | 92.9% (37,518) | **93.4% (37,751)** |
+| Base + stdlib clean | — | **85.9% (756 / 880)** |
+| Total error nodes | 85,192 | **37,479 (−56%)** |
+| Files improved vs baseline | — | **256** |
+| Regressions | — | 1 (accepted, pathological `$$` benchmark) |
+
+Hard parse exceptions: 0 (both builds).
+
+### Reproducing the table
+
+Two committed scripts over a corpus, comparing this branch's `dist/` against a
+build of the baseline ref. Runtime is a few minutes per corpus pass.
+
+**1. Build the corpus list** (paths are for macOS `juliaup`; adjust for your
+Julia install — `base/` + `stdlib/` live under `<julia>/share/julia/`):
+
+```sh
+J='~/.julia/juliaup'   # find the active version's base + stdlib
+find $J -path '*/julia-1.12*/share/julia/base/*'   -name '*.jl' >  /tmp/corpus-base.txt
+find $J -path '*/julia-1.12*/share/julia/stdlib/*' -name '*.jl' >> /tmp/corpus-base.txt
+cat /tmp/corpus-base.txt              >  /tmp/corpus-all.txt
+find ~/.julia/packages -name '*.jl'   >> /tmp/corpus-all.txt
+```
+
+**2. Build "after" (this branch) and "before" (the baseline ref):**
+
+```sh
+npm run prepare                       # "after" → dist/ (~2 min)
+
+BASE=origin/main                      # the commit this branch forked from
+mkdir -p tmp-main-build
+git show $BASE:src/julia.grammar > tmp-main-build/julia.grammar
+git show $BASE:src/highlight.js  > tmp-main-build/highlight.js
+git show $BASE:src/tokens.js \
+  | sed 's|"./julia.grammar.terms"|"./julia.grammar.terms.js"|' > tmp-main-build/tokens.js
+node_modules/.bin/lezer-generator tmp-main-build/julia.grammar -o tmp-main-build/julia.grammar.js
+```
+
+**3. Generate the numbers:**
+
+```sh
+node experiments/diff-vs-main.mjs   /tmp/corpus-all.txt                            # before-vs-after diff
+node experiments/error-summary.mjs  /tmp/corpus-all.txt                            # "after" clean rate
+node experiments/error-summary.mjs  /tmp/corpus-all.txt tmp-main-build/julia.grammar.js  # "before" clean rate
+node experiments/error-summary.mjs  /tmp/corpus-base.txt                           # Base+stdlib clean rate
+```
+
+**Row → source mapping:**
+
+| Table row | Command | Output line |
+|-----------|---------|-------------|
+| Files parsing clean | `error-summary.mjs <corpus> [parser]` | `files with error nodes: N (P%)` → clean = `processed − N`, `(100 − P)%` |
+| Base + stdlib clean | `error-summary.mjs /tmp/corpus-base.txt` | same line |
+| Total error nodes | `diff-vs-main.mjs` | `total error nodes: old=… new=…` |
+| Files improved | `diff-vs-main.mjs` | `different trees, fewer errors (improved): …` |
+| Regressions | `diff-vs-main.mjs` | `different trees, MORE errors (regressed): …` |
+
+`error-summary.mjs` takes an optional second arg (a parser build, relative to
+the repo root) so the same script measures the baseline build without a rebuild.

--- a/experiments/PRODUCTION-READINESS.md
+++ b/experiments/PRODUCTION-READINESS.md
@@ -1,0 +1,72 @@
+# Production-readiness report
+
+_Corpus sweep run 2026-06-16 against the build at commit `cd23f4c`._
+
+## Method
+
+For an editor grammar the production metric is **"does it error on valid
+Julia?"** — real package code is valid Julia, so every error node on a corpus
+file is a candidate bug.
+
+- **Corpus:** 40,402 real `.jl` files — Julia 1.12 Base + stdlib (883 files, the
+  gold-standard idiomatic corpus) plus every file in `~/.julia/packages`
+  (39,527).
+- **Pipeline:** parse each file → collect error-node positions → cluster the
+  source lines by a normalized skeleton → rank clusters by **how many distinct
+  packages** they span (a gap across many packages is systematic; a one-package
+  cluster is DSL/data noise) → confirm each candidate with an isolated minimal
+  snippet → measure blast radius by patching the source and re-counting errors.
+- **Tooling:** `find-gaps.mjs` (cluster error lines + rank by package span) and
+  `error-summary.mjs` (corpus error totals + CRLF attribution + worst files).
+
+## Headline
+
+- **0 hard parse exceptions** across 40k files.
+- **92.9%** of files parse with **zero** error nodes.
+- A 121-construct isolated sweep (comprehensions, generators, `where` chains,
+  broadcasting, `ccall`, operator method defs, nested destructuring, every
+  literal form, …) passes everything **except** the gaps below.
+- Most of the erroring 7.1% are **not** grammar bugs: macro DSLs
+  (DataFramesMeta `:col`, GraphPPL `@meta`), intentionally-invalid test
+  fixtures, embedded-DSL string macros, and non-code data files.
+
+## Confirmed gaps (valid Julia that errors)
+
+| # | Gap | Minimal repro | Reach | Severity |
+|---|-----|---------------|-------|----------|
+| 1 | **CRLF line endings** | `x = 1⏎y = 2` (`\r\n`) | 87 files / **14,877 error nodes = 17% of all** | Critical |
+| 2 | **`public` soft-keyword over-reach** | `x = public`, `@public x`, `macro public(…)` | common word → broad | High |
+| 3 | **`const` typed struct fields** (1.8+) | `mutable struct S; const x::Int; end` | in Base; cascades hard | High |
+| 4 | **Trailing comma in assignment LHS** | `I, J, = f()` | 21 pkgs / ~358 files | High |
+| 5 | **Interpolated / keyword fn & macro names** | `function Mod.$op(…)`, `function $f end`, `@try` | 8+ pkgs | Medium |
+| 6 | **Dotted macro import** | `import Base.@kwdef` | 9 pkgs incl. stdlib | Medium |
+| 7 | **Interpolated `export`** | `export $sym`, `:(export $x)` | 5 pkgs | Medium |
+| 8 | **`abstract type T; end`** (semicolon) | `abstract type T; end` | 5 pkgs | Low |
+| 9 | **Arrow with non-trivial LHS** | `f() -> body`, `a.b -> body` | rare (DSLs) | Low |
+
+### Root causes traced
+
+- **#1 CRLF** — the `newline` external tokenizer in `src/tokens.js` skips
+  trailing spaces/tabs but **not `\r`**, and only matches `\n`. So `\r\n`
+  produces no newline token. Blocks survive (their trailing separator is
+  optional) but the top level and matrix/vcat rows break. This was the mystery
+  11k-line PolygonOps cluster (a `[(float,float)⏎…]` data file saved with CRLF).
+- **#2 `public`** — `src/julia.grammar` uses `kw<'public'>` (a *hard* keyword)
+  where `as`/`outer` correctly use the soft `kwid<>` form, so `public` can never
+  be an identifier or macro name. `public x, y` (the actual statement) still works.
+- **#3 `const` field** — `ConstStatement` requires an assignment, so a bare
+  `const x::T` field declaration fails and cascades through the whole struct and
+  the rest of the file (base/lock.jl: 11 error nodes → 0 once removed).
+
+Fixing just **#1 + #3** takes 131 corpus files from erroring to fully clean.
+
+## Recommendation
+
+The two with the widest real-world blast radius are **CRLF** (any
+Windows-authored or pasted cell) and **`public`** (an ordinary English word real
+code uses as a variable); both are small, well-isolated fixes. **`const` struct
+fields** is next — a standard since Julia 1.8, present in Base, and it cascades.
+Items #4–#9 are a metaprogramming long tail.
+
+Every grammar change must be validated with the `experiments/` corpus diff
+demanding **0 regressions** before merge.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -44,6 +44,26 @@ node experiments/find-regression.js path/to/file.jl
 node experiments/perf.mjs /tmp/julia-corpus-big.txt
 ```
 
+## find-gaps.mjs, error-summary.mjs
+
+Find *valid Julia the parser errors on* (as opposed to regressions vs a previous
+build). Real package code is valid Julia, so every error node on a corpus file
+is a candidate grammar gap.
+
+```
+# Build a corpus (packages + optionally Base/stdlib):
+find ~/.julia/packages -name '*.jl' > /tmp/corpus.txt
+
+# Cluster error lines, ranked by how many distinct packages each spans
+# (many packages = systematic gap; one package = DSL/data noise):
+node experiments/find-gaps.mjs /tmp/corpus.txt
+
+# Corpus error totals, CRLF attribution, and the worst files:
+node experiments/error-summary.mjs /tmp/corpus.txt
+```
+
+See `PRODUCTION-READINESS.md` for a writeup of a full run.
+
 ## diff-vs-main.mjs
 
 Same as diff-corpus.js, but compares against a standalone build of the

--- a/experiments/error-summary.mjs
+++ b/experiments/error-summary.mjs
@@ -1,0 +1,33 @@
+// Corpus-wide error summary: how many files error, how many error nodes, and
+// how much is attributable to CRLF (the one always-safe mechanical patch — a
+// useful confound to subtract before reading `find-gaps.mjs` output). Also
+// lists the worst files so you can drill in with `find-regression.js`.
+//
+// Usage: node experiments/error-summary.mjs /tmp/corpus.txt
+import { readFileSync } from "node:fs";
+const { parser } = await import("../dist/index.js");
+const files = readFileSync(process.argv[2], "utf8").trim().split("\n");
+
+function errs(code) { let n = 0; parser.parse(code).iterate({ enter(x) { if (x.type.isError) n++; } }); return n; }
+
+let processed = 0, errFiles = 0, totalErr = 0, crlfCleaned = 0, crlfErrNodes = 0;
+const worst = [];
+for (const f of files) {
+  let code; try { code = readFileSync(f, "utf8"); } catch { continue; }
+  processed++;
+  const e0 = errs(code);
+  if (e0 === 0) continue;
+  errFiles++; totalErr += e0;
+  worst.push([f, e0]);
+  const e1 = errs(code.replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
+  if (e1 === 0) crlfCleaned++;
+  crlfErrNodes += e0 - e1;
+}
+
+console.log(`files processed:        ${processed}`);
+console.log(`files with error nodes: ${errFiles} (${(100 * errFiles / processed).toFixed(1)}%)`);
+console.log(`total error nodes:      ${totalErr}`);
+console.log(`-> cleaned by CRLF norm:  ${crlfCleaned} files / ${crlfErrNodes} error nodes`);
+console.log(`\nworst files (top 25):`);
+for (const [f, e] of worst.sort((a, b) => b[1] - a[1]).slice(0, 25))
+  console.log(`  ${e}\t${f.replace(/.*\/(packages|share\/julia)\//, "$1/")}`);

--- a/experiments/error-summary.mjs
+++ b/experiments/error-summary.mjs
@@ -3,9 +3,16 @@
 // useful confound to subtract before reading `find-gaps.mjs` output). Also
 // lists the worst files so you can drill in with `find-regression.js`.
 //
-// Usage: node experiments/error-summary.mjs /tmp/corpus.txt
+// Usage: node experiments/error-summary.mjs <corpus.txt> [parser.js]
+//   parser.js (optional, relative to the repo root) selects which build to
+//   measure; defaults to dist/index.js. Point it at a baseline standalone
+//   build (e.g. tmp-main-build/julia.grammar.js, see diff-vs-main.mjs) to get
+//   the "before" numbers without rebuilding dist/.
 import { readFileSync } from "node:fs";
-const { parser } = await import("../dist/index.js");
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+const parserPath = process.argv[3] || "dist/index.js";
+const { parser } = await import(pathToFileURL(resolve(parserPath)).href);
 const files = readFileSync(process.argv[2], "utf8").trim().split("\n");
 
 function errs(code) { let n = 0; parser.parse(code).iterate({ enter(x) { if (x.type.isError) n++; } }); return n; }

--- a/experiments/find-gaps.mjs
+++ b/experiments/find-gaps.mjs
@@ -1,0 +1,55 @@
+// Find valid Julia the parser errors on. Real package code is valid Julia, so
+// every error node on a corpus file is a candidate grammar gap. Clusters error
+// lines by a normalized skeleton and ranks clusters by how many DISTINCT
+// packages they span: a cluster across many packages is a systematic gap; a
+// single-package cluster is usually a macro DSL or data file.
+//
+// Usage: node experiments/find-gaps.mjs /tmp/corpus.txt [minPkgs=3]
+//   where corpus.txt is a list of .jl paths, e.g.
+//   find ~/.julia/packages -name '*.jl' > /tmp/corpus.txt
+import { readFileSync } from "node:fs";
+const { parser } = await import("../dist/index.js");
+
+const files = readFileSync(process.argv[2], "utf8").trim().split("\n");
+const minPkgs = process.argv[3] ? +process.argv[3] : 3;
+
+function skeleton(line) {
+  let s = line.trim();
+  s = s.replace(/"(?:[^"\\]|\\.)*"/g, '"S"').replace(/'(?:[^'\\]|\\.)'/g, "'C'").replace(/#.*$/, "");
+  s = s.replace(/\b\d[\d_.eE+\-]*\b/g, "N");
+  const kw = new Set(["function","end","for","while","if","else","elseif","begin","let","do","try","catch","finally","return","const","global","local","struct","mutable","module","using","import","export","macro","quote","where","in","isa"]);
+  s = s.replace(/[A-Za-z_¡-￿][\w!¡-￿]*/g, (m) => kw.has(m) ? m : "i");
+  s = s.replace(/\s+/g, " ").replace(/(?:i[.,] ?)+i/g, "i");
+  return s.slice(0, 80);
+}
+function pkgOf(f) {
+  const m = f.match(/\/packages\/([^/]+)\//); if (m) return "pkg:" + m[1];
+  const j = f.match(/\/share\/julia\/(\w+)/); if (j) return "julia:" + j[1];
+  return f;
+}
+
+const clusters = new Map();
+for (const f of files) {
+  let code; try { code = readFileSync(f, "utf8"); } catch { continue; }
+  code = code.replace(/\r\n/g, "\n").replace(/\r/g, "\n"); // ignore CRLF noise
+  const errLines = new Set();
+  parser.parse(code).iterate({ enter(n) { if (n.type.isError) errLines.add(code.slice(0, n.from).split("\n").length); } });
+  if (!errLines.size) continue;
+  const lines = code.split("\n"), pkg = pkgOf(f);
+  for (const ln of errLines) {
+    const src = (lines[ln - 1] || "").trim(); if (!src) continue;
+    const sk = skeleton(src);
+    if (!clusters.has(sk)) clusters.set(sk, { lines: 0, pkgs: new Set(), examples: [] });
+    const c = clusters.get(sk);
+    c.lines++; c.pkgs.add(pkg);
+    if (c.examples.length < 3 && !c.examples.some((e) => e.pkg === pkg))
+      c.examples.push({ pkg, f: f.replace(/.*\/(packages|julia)\//, "$1:"), ln, src: src.slice(0, 90) });
+  }
+}
+
+const sorted = [...clusters.entries()].filter(([, c]) => c.pkgs.size >= minPkgs).sort((a, b) => b[1].pkgs.size - a[1].pkgs.size);
+console.log(`clusters spanning >=${minPkgs} packages (systematic candidates): ${sorted.length}\n`);
+for (const [sk, c] of sorted) {
+  console.log(`[${c.pkgs.size} pkgs, ${c.lines} lines]  ${sk}`);
+  for (const ex of c.examples.slice(0, 2)) console.log(`    ${ex.f}:${ex.ln}  ${ex.src}`);
+}

--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -115,11 +115,11 @@ simple-statement {
   ( BreakStatement { kw<'break'> }
   | ContinueStatement { kw<'continue'> }
   | ReturnStatement { kw<'return'> (!simple top-level)? }
-  | ConstStatement  { kw<'const'>  !simple OpenAssignment }
+  | ConstStatement  { kw<'const'>  !simple top-level }
   | GlobalStatement { kw<'global'> !simple top-level }
   | LocalStatement  { kw<'local'>  !simple top-level }
   | ExportStatement { kw<'export'> !simple sep1<(!tup ','), exportable> }
-  | PublicStatement { kw<'public'> !simple sep1<(!tup ','), exportable> }
+  | PublicStatement { kwid<'public'> !simple sep1<(!tup ','), exportable> }
   | ImportStatement { kw<'import'> !simple (import-list | SelectedImport) }
   | UsingStatement { kw<'using'> !simple (import-list | SelectedImport) }
   )

--- a/src/julia.grammar
+++ b/src/julia.grammar
@@ -526,7 +526,7 @@ _t { newline | semicolon }
   dec { $[0-9] }
   hex { $[0-9A-Fa-f] }
   exp { $[Eef] $[+-]? dec+ }
-  hex-exp { 'p' $[+-]? dec+ }
+  hex-exp { $[pP] $[+-]? dec+ }
 
   FloatLiteral {
     numeral<dec> ('.' numeral<dec>? exp? | exp)

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -4,6 +4,7 @@ import * as terms from "./julia.grammar.terms"; // Not a real file. "linked" by 
 // UNICODE CODEPOINTS
 
 const CHAR_NEWLINE = "\n".codePointAt(0);
+const CHAR_CR = "\r".codePointAt(0);
 
 const CHAR_EXCLAMATION = "!".codePointAt(0);
 const CHAR_EQUALS = "=".codePointAt(0);
@@ -249,10 +250,15 @@ export const newline = new ExternalTokenizer(
     while (c === 0x20 /* space */ || c === 0x09 /* tab */) {
       c = input.peek(++offset);
     }
-    // Consume one or more newline characters.
+    // Consume one or more newline characters. Julia treats `\n`, `\r` and
+    // `\r\n` all as line breaks, so accept carriage returns too — otherwise a
+    // CRLF file produces no newline token and every statement boundary (and
+    // every matrix/vcat row) past the first errors.
     const nlStart = offset;
-    while (input.peek(offset) === CHAR_NEWLINE) {
+    let nl = input.peek(offset);
+    while (nl === CHAR_NEWLINE || nl === CHAR_CR) {
       offset += 1;
+      nl = input.peek(offset);
     }
     // Only produce the token if we found at least one newline and the
     // current parser state accepts it as a statement separator.
@@ -369,7 +375,7 @@ export const spaceSep = new ExternalTokenizer(
     let c = input.peek(offset);
     if (!isWhitespace(c)) return;
     while (isWhitespace(c)) {
-      if (c === CHAR_NEWLINE) return;
+      if (c === CHAR_NEWLINE || c === CHAR_CR) return;
       c = input.peek(--offset);
     }
     if (stack.canShift(terms.spaceSep)) {

--- a/test/literals.txt
+++ b/test/literals.txt
@@ -47,8 +47,15 @@ Program(
 0x0123456789_abcdef_ABCDEF.p-1
 0x.0123456789_abcdef_ABCDEFp1
 
+0x1.8P3
+0x0.0000000000000P+0
+0x.aP-1064
+
 ==>
 Program(
+  FloatLiteral,
+  FloatLiteral,
+  FloatLiteral,
   FloatLiteral,
   FloatLiteral,
   FloatLiteral,

--- a/test/statements.txt
+++ b/test/statements.txt
@@ -544,6 +544,48 @@ Program(
   )
 )
 
+
+# Const statements - typed const and const struct fields (Julia 1.8+)
+
+const x::Int = 1
+
+mutable struct Event
+    const notify::Int
+    const autoreset
+    set::Bool
+end
+
+==>
+Program(
+  ConstStatement(const, Assignment(BinaryExpression(Identifier, "::", Type(Identifier)), AssignmentOp, IntegerLiteral)),
+  StructDefinition(
+    mutable, struct, TypeHead(Identifier),
+    ConstStatement(const, BinaryExpression(Identifier, "::", Type(Identifier))),
+    ConstStatement(const, Identifier),
+    BinaryExpression(Identifier, "::", Type(Identifier)),
+    end
+  )
+)
+
+
+# Public used as an identifier (soft keyword)
+
+public a, b
+public
+x = public
+f(public)
+@public x
+
+==>
+Program(
+  PublicStatement(public, Identifier, Identifier),
+  Identifier,
+  Assignment(Identifier, AssignmentOp, Identifier),
+  CallExpression(Identifier, Arguments(Identifier)),
+  MacrocallExpression(MacroIdentifier(Identifier), MacroArguments(Identifier))
+)
+
+
 # Local statements
 
 local x

--- a/test/test-crlf.js
+++ b/test/test-crlf.js
@@ -1,0 +1,46 @@
+// CRLF (`\r\n`) line endings must work like LF. Kept as a JS test rather than
+// a `.txt` fileTest because literal carriage returns in a text fixture are
+// fragile (editors/git normalize them). Julia treats `\n`, `\r` and `\r\n` all
+// as line breaks; the `newline` external tokenizer used to recognize only `\n`,
+// so every statement boundary and matrix/vcat row past the first errored in a
+// CRLF file.
+import { parser } from "../dist/index.js";
+import assert from "node:assert";
+
+function errorCount(code) {
+  let n = 0;
+  parser.parse(code).iterate({ enter(node) { if (node.type.isError) n++; } });
+  return n;
+}
+
+describe("crlf", () => {
+  const CR = "\r\n";
+  const cases = {
+    "two top-level statements": `x = 1${CR}y = 2`,
+    "three top-level statements": `a()${CR}b()${CR}c()`,
+    "begin block, two statements": `begin${CR}x = 1${CR}y = 2${CR}end`,
+    "function body": `function f()${CR}  x${CR}  y${CR}end`,
+    "vcat, one element per line": `[1${CR}2${CR}3]`,
+    "matrix rows": `[1 2${CR}3 4]`,
+    "vcat of tuples": `[(1,2)${CR}(3,4)${CR}(5,6)]`,
+    "blank line between statements": `x = 1${CR}${CR}y = 2`,
+  };
+
+  for (const [name, code] of Object.entries(cases)) {
+    it(name, () => {
+      assert.strictEqual(
+        errorCount(code),
+        0,
+        `expected no error nodes for CRLF input ${JSON.stringify(code)}`,
+      );
+    });
+  }
+
+  it("parses CRLF the same as LF", () => {
+    for (const code of Object.values(cases)) {
+      const crlf = parser.parse(code).toString();
+      const lf = parser.parse(code.replace(/\r\n/g, "\n")).toString();
+      assert.strictEqual(crlf, lf, `tree differs for ${JSON.stringify(code)}`);
+    }
+  });
+});


### PR DESCRIPTION
Four valid-Julia mis-parses surfaced by a 40k-file corpus sweep (Julia 1.12 Base+stdlib + all `~/.julia/packages`). Full writeup and the reusable gap-finding harness are in [`experiments/PRODUCTION-READINESS.md`](experiments/PRODUCTION-READINESS.md).

## Fixes

| Construct | Before | After |
|-----------|--------|-------|
| `x = 1⏎y = 2` (CRLF) | error at every statement boundary | parses |
| `x = public`, `@public x`, `macro public(…)` | error | parses (`public x, y` still works) |
| `mutable struct S; const x::Int; end` | error (cascades through the struct) | parses |
| `0x1.8P3`, `0x0.0P+0` (uppercase-`P` hex float) | error | parses |

- **CRLF** — the `newline` external tokenizer only matched `\n`, so a `\r\n` file produced no newline token and every statement boundary + matrix/vcat row past the first errored. Now accepts `\r`/`\r\n` (and in `spaceSep`'s row-separator check).
- **`public`** — was a hard keyword (`kw<'public'>`), so it couldn't be used as an identifier/macro name. Now a soft keyword (`kwid<'public'>`, like `as`/`outer`); the `public x, y` statement still parses.
- **`const` struct fields** — `const x::T` field declarations (Julia 1.8+, used throughout Base) errored because `ConstStatement` required an assignment. Now uses `top-level` (matching `global`/`local`). `const x = 1` keeps its exact tree.
- **Uppercase-`P` hex floats** ([#50](https://github.com/JuliaPluto/lezer-julia/issues/50)) — `hex-exp` matched only lowercase `p`, so `0x1.8P3` errored. Now accepts `$[pP]`.

## Completeness (40,402-file corpus)

| Metric | Pre-PR baseline | After this PR |
|--------|-----------------|---------------|
| Files parsing clean (zero error nodes) | 92.9% (37,518) | **93.4% (37,751)** |
| Base + stdlib clean | — | **85.9% (756 / 880)** |
| Total error nodes | 85,192 | **37,479 (−56%)** |
| Files improved vs baseline | — | **256** |
| Regressions | — | 1 (accepted, pathological) |

Hard parse exceptions: 0. **139 unit tests pass** (incl. new CRLF, typed-const / const-struct-field, `public`-as-identifier, and uppercase-`P` hex-float cases). The one regression is a non-interactive `MLStyle` benchmark hitting a *pre-existing* `$$`-interpolation weakness (4→5 nodes), not a new `const` bug — a truly-0-regression `const` fix is infeasible (`const` is reachable inside `expr`, so any narrower rule is a fatal reduce/reduce conflict). The hex-float fix alone removed ~31k error nodes (IntervalArithmetic's ITF1788 suite uses uppercase `P` exclusively; e.g. `fi_lib.jl` went 6962 → 0).

How to regenerate this table: see [Reproducing the table](experiments/PRODUCTION-READINESS.md#reproducing-the-table).

Remaining gaps are tracked as separate issues: [#51](https://github.com/JuliaPluto/lezer-julia/issues/51)–[#57](https://github.com/JuliaPluto/lezer-julia/issues/57). CLAUDE.md gotchas updated. `dist/` not committed; `package.json` not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)